### PR TITLE
fix: use exec review subcommand in codex-review skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmagic",
   "description": "Advanced project management commands for Claude Code",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": { "name": "Devon Hillard", "url": "https://github.com/devondragon" },
   "repository": "https://github.com/devondragon/ccmagic",
   "license": "Apache-2.0"

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -66,6 +66,7 @@ Collect into `{PROJECT_CONVENTIONS}` for the Claude triage pass and Claude-origi
 git diff --name-only main...HEAD
 git diff --stat main...HEAD
 git log --oneline main...HEAD
+git diff main...HEAD > /tmp/codex-review-diff.txt
 ```
 
 ### PR mode
@@ -152,9 +153,10 @@ For each dimension, run available tools in parallel:
 REVIEW_MODEL="${MODEL:-gpt-5.3-codex}"
 FALLBACK_MODEL="${FALLBACK_MODEL:-gpt-5-codex}"
 
-# Inject dimension-specific prompt from codex-prompts.md
-cat /tmp/codex-{dimension}-prompt.txt | \
-  codex --model ${REVIEW_MODEL} --full-auto exec review --base main - \
+# Inject dimension-specific prompt and diff content via stdin
+# (--base and [PROMPT] are mutually exclusive in codex; pipe diff instead)
+cat /tmp/codex-{dimension}-prompt.txt /tmp/codex-review-diff.txt | \
+  codex --model ${REVIEW_MODEL} --full-auto exec - \
   2>&1 | tee /tmp/codex-{dimension}-output.txt
 ```
 

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -154,7 +154,7 @@ FALLBACK_MODEL="${FALLBACK_MODEL:-gpt-5-codex}"
 
 # Inject dimension-specific prompt from codex-prompts.md
 cat /tmp/codex-{dimension}-prompt.txt | \
-  codex --model ${REVIEW_MODEL} --full-auto review --base main - \
+  codex --model ${REVIEW_MODEL} --full-auto exec review --base main - \
   2>&1 | tee /tmp/codex-{dimension}-output.txt
 ```
 


### PR DESCRIPTION
## Summary

Fixes `ccmagic:codex-review` broken Codex invocation.

**Root cause:** `--base <BRANCH>` and `[PROMPT]` (stdin or literal) are mutually exclusive in both `codex review` and `codex exec review` — a clap-level conflict. The skill was trying to pipe a dimension-specific prompt while also scoping to `--base main`, which always fails.

**Fix:**
- Branch mode (Step 3): save `git diff main...HEAD` to `/tmp/codex-review-diff.txt`
- Codex pass (Step 4): pipe `prompt + diff` into `codex exec -` with no `--base` — matching the pattern already used in full mode (line 172)

Note: an earlier commit on this branch used `exec review --base main -` which also fails for the same reason. That has been superseded by this commit.

Closes #12

## Test plan

- [ ] Run `ccmagic:codex-review` on a branch with changes against main
- [ ] Confirm codex receives the diff content via stdin (no `--base` conflict error)
- [ ] Confirm dimension-specific prompts are passed correctly