### PR TITLE
fix(skills): add name field to SKILL.md frontmatter

### DIFF
--- a/skills/analyze-impact/SKILL.md
+++ b/skills/analyze-impact/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: analyze-impact
 user-invocable: true
 allowed-tools: Read(*), Bash(git:*), Glob(*), Grep(*), Task(*), TodoWrite(*), mcp__pal__analyze(*)
 description: Analyze blast radius and dependencies for a file or feature

--- a/skills/browser-qa/SKILL.md
+++ b/skills/browser-qa/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: browser-qa
 description: Systematically QA test a web app in a real browser — find bugs, fix them, verify with screenshots
 allowed-tools: Read(*), Write(*), Edit(*), Bash(git:*, curl:*), Glob(*), Grep(*), Agent(*), AskUserQuestion(*), mcp__chrome_devtools__navigate_page(*), mcp__chrome_devtools__take_screenshot(*), mcp__chrome_devtools__take_snapshot(*), mcp__chrome_devtools__evaluate_script(*), mcp__chrome_devtools__resize_page(*), mcp__chrome_devtools__click(*), mcp__chrome_devtools__fill(*), mcp__chrome_devtools__fill_form(*), mcp__chrome_devtools__press_key(*), mcp__chrome_devtools__hover(*), mcp__chrome_devtools__list_console_messages(*), mcp__chrome_devtools__list_network_requests(*), mcp__chrome_devtools__lighthouse_audit(*), mcp__chrome_devtools__wait_for(*)
 argument-hint: "[URL] [--quick|--exhaustive] [--scope PAGE]"

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: codex-review
 user-invocable: true
 allowed-tools: Read(*), Bash(*), Glob(*), Grep(*), Task(*), TodoWrite(*), AskUserQuestion(*)
 description: Multi-model code review (Codex + Gemini + Claude triage) with dimension-focused passes

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: debug
 user-invocable: true
 allowed-tools: Read(*), Write(*), Edit(*), Bash(*), Glob(*), Grep(*), Task(*), TodoWrite(*), AskUserQuestion(*)
 description: Systematic debugging with scientific method, parallel investigation, and persistent sessions

--- a/skills/design-explore/SKILL.md
+++ b/skills/design-explore/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: design-explore
 description: Generate multiple distinct design directions, compare in browser, pick a winner before building
 allowed-tools: Read(*), Write(*), Edit(*), Bash(git:*, curl:*), Glob(*), Grep(*), Agent(*), AskUserQuestion(*), mcp__chrome_devtools__navigate_page(*), mcp__chrome_devtools__take_screenshot(*), mcp__chrome_devtools__evaluate_script(*), mcp__chrome_devtools__resize_page(*)
 argument-hint: "[page/component description] [--count N] [--evolve URL]"

--- a/skills/design-qa/SKILL.md
+++ b/skills/design-qa/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: design-qa
 description: Design quality audit — catches AI slop, scores visual polish, fixes issues with atomic commits
 allowed-tools: Read(*), Edit(*), Write(*), Bash(git:*), Glob(*), Grep(*), Agent(*), AskUserQuestion(*), mcp__chrome_devtools__navigate_page(*), mcp__chrome_devtools__take_screenshot(*), mcp__chrome_devtools__evaluate_script(*), mcp__chrome_devtools__resize_page(*), mcp__chrome_devtools__take_snapshot(*), mcp__chrome_devtools__lighthouse_audit(*), mcp__chrome_devtools__list_console_messages(*)
 argument-hint: "[URL] [--quick|--deep|--diff]"

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: doctor
 user-invocable: true
 allowed-tools: Read(*), Glob(*), Bash(*)
 description: Diagnose CCMagic setup issues and validate installation

--- a/skills/finish-ticket/SKILL.md
+++ b/skills/finish-ticket/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: finish-ticket
 description: Closes out a development ticket end-to-end. Detects the tracker (Linear, GitHub Issues, or JIRA) and the ticket from the current branch, sanity-checks the PR, confirms disposition (Done by default, or QA when configured/requested), merges the PR, and updates the ticket with a comment, PR link, and final status.
 user-invocable: true
 allowed-tools: Read(*), Edit(*), Bash(git:*, gh:*), Glob(*), Grep(*), AskUserQuestion(*), Skill(*)

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: help
 user-invocable: true
 allowed-tools: Read(*), Glob(*), Bash(git:*)
 description: Interactive help and command reference with examples

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: init
 user-invocable: true
 allowed-tools: Read(*), Write(*), Bash(git:*), Bash(mkdir:*), Bash(touch:*), AskUserQuestion(*)
 description: Bootstrap ccmagic project config — conventions, branching strategy, knowledge directory, and tracker settings

--- a/skills/map-codebase/SKILL.md
+++ b/skills/map-codebase/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: map-codebase
 user-invocable: true
 allowed-tools: Read(*), Glob(*), LS(*), Grep(*), Task(*), Write(*), Bash(mkdir:*)
 description: Analyze existing codebase and document patterns

--- a/skills/merge/SKILL.md
+++ b/skills/merge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: merge
 user-invocable: true
 allowed-tools: Read(*), Bash(git:*), Bash(gh:*), Bash(glab:*), Bash(curl:*), Glob(*)
 description: Safely merge approved PRs with strategy-aware branch handling

--- a/skills/pr-feedback/SKILL.md
+++ b/skills/pr-feedback/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: pr-feedback
 user-invocable: true
 allowed-tools: Read(*), Bash(git:*, gh:*), Glob(*), Grep(*), Task(*), TodoWrite(*), AskUserQuestion(*), Edit(*)
 description: Review PR comments and plan fixes for valid concerns

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: pr
 user-invocable: true
 allowed-tools: Read(*), Bash(git:*), Bash(gh:*), Bash(glab:*), Glob(*), Task(*)
 description: Create pull request with platform detection and smart description generation

--- a/skills/push/SKILL.md
+++ b/skills/push/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: push
 user-invocable: true
 description: Smart commit and push with logical grouping
 allowed-tools: Read(*), Bash(git:*), Glob(*), AskUserQuestion(*), Write(*)

--- a/skills/quick/SKILL.md
+++ b/skills/quick/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: quick
 user-invocable: true
 allowed-tools: Write(*), Read(*), Edit(*), Bash(*), Glob(*), LS(*), Grep(*), Task(*), TodoWrite(*), AskUserQuestion(*)
 description: Execute ad-hoc task without feature overhead

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: research
 user-invocable: true
 description: Deep iterative research with parallel exploration, source evaluation, and confidence scoring
 argument-hint: <topic or question to research>

--- a/skills/review-ticket/SKILL.md
+++ b/skills/review-ticket/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review-ticket
 description: Ticket-grounded code review. Fetches the ticket from Linear, GitHub Issues, or JIRA, then runs /ccmagic:review with the ticket scope as the primary intent source. Adds an explicit Ticket-scope drift section (in-scope / out-of-scope / missing-from-ticket).
 user-invocable: true
 allowed-tools: Read(*), Edit(*), Bash(git:*, gh:*), Glob(*), Grep(*), Agent(*), Task(*), TodoWrite(*), AskUserQuestion(*), Skill(*)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review
 user-invocable: true
 allowed-tools: Read(*), Edit(*), Bash(git:*, gh:*, codex:*, which:*), Glob(*), Grep(*), Agent(*), Task(*), TodoWrite(*), AskUserQuestion(*), mcp__pal__codereview(*)
 description: Adaptive code review — auto-routes between a fast inline checklist (QUICK) and the full multi-agent pipeline (DEEP) with confidence scoring and convention awareness. Biased toward depth.

--- a/skills/settings/SKILL.md
+++ b/skills/settings/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: settings
 user-invocable: true
 allowed-tools: Read(*), Write(*), AskUserQuestion(*)
 description: Configure CCMagic preferences (tracker, QA workflow, ticket regex)

--- a/skills/test/SKILL.md
+++ b/skills/test/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: test
 user-invocable: true
 allowed-tools: Read(*), Bash(*), Glob(*), Grep(*), Task(*), TodoWrite(*)
 description: Run tests with framework auto-detection, smart selection, coverage analysis, and failure diagnosis

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: validate
 user-invocable: true
 allowed-tools: Read(*), Bash(*), Glob(*), Task(*), TodoWrite(*)
 description: Comprehensive pre-commit validation with parallel checks

--- a/skills/work-ticket/SKILL.md
+++ b/skills/work-ticket/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: work-ticket
 description: End-to-end ticket workflow. Detects your tracker (Linear, GitHub Issues, or JIRA), looks up the ticket, assigns it to you, moves it to In Progress, triages the work type, creates a branch, executes the work (delegating to /ccmagic:debug for bugs), validates scope, then commits and opens a PR.
 user-invocable: true
 allowed-tools: Read(*), Write(*), Edit(*), Bash(git:*, gh:*, mkdir:*), Glob(*), Grep(*), Task(*), TodoWrite(*), AskUserQuestion(*), Skill(*)


### PR DESCRIPTION
## What
Add a `name:` field to the YAML frontmatter of all 23 skills, matching each skill's kebab-case directory name (e.g. `name: finish-ticket`).

## Why
The marketplace/sandbox plugin validator was failing with:
- `files[SKILL.md].content: front matter must include a string name` (×23 — UI truncated to 7)
- `files: items of type "plugin" require a plugin manifest at ".claude-plugin/plugin.json"` — a **cascade** from the invalid skill items; the manifest itself is present and valid.

Claude Code's plugin loader infers a skill's name from its directory, so the missing field was silent locally — but the external validator requires an explicit `name` string.

## How to test
- `gh` marketplace/sandbox validation passes (no more `front matter must include a string name`).
- Locally: `claude --plugin-dir ./` — all skills still load and appear.

Only frontmatter was touched; no skill behavior changed. One file (`analyze-impact`) also gained a trailing newline at EOF (benign normalization).