### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ccmagic",
       "source": "./",
       "description": "23 dev workflow skills: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "author": {
         "name": "Devon Hillard"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmagic",
   "description": "Dev workflow skills for Claude Code: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": { "name": "Devon Hillard", "url": "https://github.com/devondragon" },
   "repository": "https://github.com/devondragon/ccmagic",
   "license": "Apache-2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ccmagic are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] — 2026-07
+
+### Fixed
+
+- Add the required `name` field to the YAML frontmatter of all 23 skills. The field matches each skill's kebab-case directory (e.g. `name: finish-ticket`). Claude Code's plugin loader infers the name from the directory, so the omission was silent locally, but the marketplace/sandbox validator requires an explicit `name` string — its absence caused `front matter must include a string name` errors and a cascading plugin-manifest rejection.
+
 ## [3.0.0] — 2026-05
 
 **Breaking change.** ccmagic refocuses from project management to dev workflow. 23 planning/state-management skills have been removed; 3 new tracker-aware skills have been added; a non-blocking commit-format hook now ships with the plugin.


### PR DESCRIPTION
## What
Patch release bumping the plugin version `3.0.0` → `3.0.1` in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, plus a matching `CHANGELOG.md` entry.

## Why
Follows #15, which added the required `name` frontmatter field to all 23 skills. That was a semver **patch** (`fix:`), and the marketplace/sandbox validator dedupes by version — a bump is needed for the corrected plugin to be re-ingested.

## How to test
- `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` both report `3.0.1`.
- `CHANGELOG.md` documents the `[3.0.1]` fixed entry.