### PR TITLE
fix(hooks): add required timeout to PostToolUse hook (3.0.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ccmagic",
       "source": "./",
       "description": "23 dev workflow skills: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "author": {
         "name": "Devon Hillard"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmagic",
   "description": "Dev workflow skills for Claude Code: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": { "name": "Devon Hillard", "url": "https://github.com/devondragon" },
   "repository": "https://github.com/devondragon/ccmagic",
   "license": "Apache-2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ccmagic are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] — 2026-07
+
+### Fixed
+
+- Add the required `timeout` field (10s) to the PostToolUse hook entry in `hooks/hooks.json`. Claude Code treats the field as optional, but the marketplace/sandbox validator requires `timeout` (or `timeoutMs`) on every hook, which caused a `hook timeout or timeoutMs is required` error and a cascading plugin-manifest rejection.
+
 ## [3.0.1] — 2026-07
 
 ### Fixed

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use-commit.sh\""
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use-commit.sh\"",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## What
- Add `"timeout": 10` to the PostToolUse hook entry in `hooks/hooks.json`.
- Bump `3.0.1` → `3.0.2` in `plugin.json` and `marketplace.json`, with a matching `CHANGELOG.md` entry.

## Why
The marketplace/sandbox validator requires a `timeout` (or `timeoutMs`) field on every hook:
- `files[hooks/hooks.json].content.hooks.PostToolUse[0].hooks[0]: hook timeout or timeoutMs is required`
- `files: items of type "plugin" require a plugin manifest ...` — the same **cascade** as before; the manifest is present and valid.

Claude Code treats `timeout` as optional (default applies), so the omission was silent locally. 10s is generous for the fast, non-blocking commit-format script.

## How to test
- Marketplace/sandbox validation passes (no `hook timeout ...` error).
- Locally: `claude --plugin-dir ./` — the commit-format hook still fires on Bash git commits.