### PR TITLE
feat: per-step subagents + per-step models for auto-ticket

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ccmagic",
       "source": "./",
       "description": "24 dev workflow skills: tracker-aware ticket lifecycle (Linear, GitHub, JIRA) with an autonomous end-to-end driver, adaptive code review, debugging, design/QA, and git workflow utilities",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "author": {
         "name": "Devon Hillard"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmagic",
   "description": "Dev workflow skills for Claude Code: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": { "name": "Devon Hillard", "url": "https://github.com/devondragon" },
   "repository": "https://github.com/devondragon/ccmagic",
   "license": "Apache-2.0"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,6 +120,8 @@ ccmagic/
 │   └── marketplace.json       # Marketplace metadata
 ├── skills/
 │   └── <name>/SKILL.md        # Skill directories, each with SKILL.md
+├── agents/
+│   └── auto-*.md              # per-step wrapper agents for auto-ticket
 ├── hooks/
 │   ├── hooks.json             # Hook manifest (PostToolUse → commit format check)
 │   └── post-tool-use-commit.sh
@@ -145,7 +147,7 @@ context: fork                  # For heavy skills (subagent isolation)
 ```
 
 - **All skills are user-invocable and model-invocable.**
-- `context: fork` skills: `map-codebase`, `review`, `codex-review`, `validate`, `analyze-impact`, `research`, `doctor`, `design-explore`, `design-qa`, `browser-qa`.
+- `context: fork` skills: `map-codebase`, `review`, `codex-review`, `validate`, `analyze-impact`, `research`, `doctor`, `design-explore`, `design-qa`, `browser-qa`, `auto-ticket`.
 - Do **not** use `disable-model-invocation: true` — it's broken for plugin skills (see [#22345](https://github.com/anthropics/claude-code/issues/22345), [#24042](https://github.com/anthropics/claude-code/issues/24042)). Re-evaluate when fixed upstream.
 
 ## Testing locally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to ccmagic are documented here. The format follows [Keep a C
 
 ### Added
 
-- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the lifecycle skills' *logic* is reused unchanged (only three of them have their `model:` line tuned (work/review → `inherit`, push → `haiku`) — see Changed). Configurable via `fork_steps` (default `true`; `false` runs the steps inline in the orchestrator (which itself still runs forked)).
+- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the lifecycle skills' *logic* is reused unchanged (only three of them have their `model:` line tuned (work/review → `inherit`, push → `haiku`) — see Changed). Each step always runs in its own forked subagent.
 - **Per-step model selection** — Balanced defaults (`opus` for work/review, `sonnet` for pr-feedback/finish/validate, `haiku` for push), overridable per repo with `model_<step>` keys. `auto-ticket` itself is now `context: fork`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to ccmagic are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] — 2026-07
+
+### Added
+
+- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the five lifecycle skills are reused unchanged. Configurable via `fork_steps` (default `true`; `false` restores the 3.1.0 inline flow).
+- **Per-step model selection** — Balanced defaults (`opus` for work/review, `sonnet` for pr-feedback/finish/validate, `haiku` for push), overridable per repo with `model_<step>` keys. `auto-ticket` itself is now `context: fork`.
+
+### Changed
+
+- **`skills/auto-ticket/SKILL.md`** — now `context: fork`; every step routes through a `run_step` helper (forked-per-step or inline). The handshake contract is unchanged; it now returns across the subagent boundary.
+
 ## [3.1.0] — 2026-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ All notable changes to ccmagic are documented here. The format follows [Keep a C
 
 ### Added
 
-- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the five lifecycle skills are reused unchanged. Configurable via `fork_steps` (default `true`; `false` restores the 3.1.0 inline flow).
+- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the five lifecycle skills' *logic* is reused unchanged (only their `model:` line is tuned — see Changed). Configurable via `fork_steps` (default `true`; `false` restores the 3.1.0 inline flow).
 - **Per-step model selection** — Balanced defaults (`opus` for work/review, `sonnet` for pr-feedback/finish/validate, `haiku` for push), overridable per repo with `model_<step>` keys. `auto-ticket` itself is now `context: fork`.
 
 ### Changed
 
 - **`skills/auto-ticket/SKILL.md`** — now `context: fork`; every step routes through a `run_step` helper (forked-per-step or inline). The handshake contract is unchanged; it now returns across the subagent boundary.
+- **Lifecycle-skill default models tuned** (part of the per-step model strategy, which removes the model-clobber risk at the source so per-step models are correct by construction): `work-ticket` and `review-ticket` now use `model: inherit` (scale to the session model instead of a pinned `sonnet`), and `push` now uses `model: haiku`. This also changes **interactive** use of those three skills — e.g. a human running `/ccmagic:push` now gets `haiku`. `pr-feedback`, `finish-ticket`, and `validate` stay `sonnet`.
 
 ## [3.1.0] — 2026-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to ccmagic are documented here. The format follows [Keep a C
 
 ### Added
 
-- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the five lifecycle skills' *logic* is reused unchanged (only their `model:` line is tuned — see Changed). Configurable via `fork_steps` (default `true`; `false` restores the 3.1.0 inline flow).
+- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the lifecycle skills' *logic* is reused unchanged (only three of them have their `model:` line tuned (work/review → `inherit`, push → `haiku`) — see Changed). Configurable via `fork_steps` (default `true`; `false` runs the steps inline in the orchestrator (which itself still runs forked)).
 - **Per-step model selection** — Balanced defaults (`opus` for work/review, `sonnet` for pr-feedback/finish/validate, `haiku` for push), overridable per repo with `model_<step>` keys. `auto-ticket` itself is now `context: fork`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ max_feedback_passes: 3         # cap on the pr-feedback loop before parking
 
 The autonomous signal is checked in priority order: **`--autonomous` arg → `autonomous: true` in the orchestrator's grounding block → `autonomous:` in `ccmagic.local.md` (project, then user)**. Absent all three, every skill runs its unchanged interactive path. Each autonomous sub-skill ends with a machine-readable status handshake (`clean | fixable-findings | needs-human | done`) that the orchestrator parses to decide the next step; the shared contract lives in `skills/auto-ticket/autonomous-contract.md`.
 
+### Per-step subagents and models
+
+By default `auto-ticket` runs each lifecycle step in its own **forked subagent** on a best-fit **model** — strong models where judgment matters, light ones for mechanical steps — which keeps the orchestrator's context lean on long unattended runs and puts the right model on each step:
+
+| Step | Default model |
+|---|---|
+| work-ticket / review-ticket | `opus` |
+| pr-feedback / finish-ticket / validate | `sonnet` |
+| push | `haiku` |
+
+Set `fork_steps: false` to run every step inline in one context instead, or override any step with `model_<step>` (e.g. `model_pr_feedback: opus`).
+
 ## Configuration
 
 ccmagic reads (and `/ccmagic:init` creates) these files in the consuming project:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ By default `auto-ticket` runs each lifecycle step in its own **forked subagent**
 | pr-feedback / finish-ticket / validate | `sonnet` |
 | push | `haiku` |
 
-Set `fork_steps: false` to run every step inline in one context instead, or override any step with `model_<step>` (e.g. `model_pr_feedback: opus`).
+Set `fork_steps: false` to run steps inline in the orchestrator instead (the orchestrator itself still runs forked), or override any step with `model_<step>` (e.g. `model_pr_feedback: opus`) (the agent file `agents/auto-<step>.md` is the authoritative model source).
 
 ## Configuration
 
@@ -271,6 +271,8 @@ ccmagic/
 │   └── marketplace.json
 ├── skills/
 │   └── <name>/SKILL.md
+├── agents/
+│   └── auto-*.md              # per-step wrapper agents for auto-ticket
 ├── hooks/
 │   ├── hooks.json
 │   └── post-tool-use-commit.sh

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ By default `auto-ticket` runs each lifecycle step in its own **forked subagent**
 | pr-feedback / finish-ticket / validate | `sonnet` |
 | push | `haiku` |
 
-Set `fork_steps: false` to run steps inline in the orchestrator instead (the orchestrator itself still runs forked), or override any step with `model_<step>` (e.g. `model_pr_feedback: opus`) (the agent file `agents/auto-<step>.md` is the authoritative model source).
+Each step always runs in its own subagent — override any step's model with `model_<step>` (e.g. `model_pr_feedback: opus`) (the agent file `agents/auto-<step>.md` is the authoritative model source).
 
 ## Configuration
 

--- a/agents/auto-feedback.md
+++ b/agents/auto-feedback.md
@@ -1,0 +1,28 @@
+---
+name: auto-feedback
+description: Autonomous-run PR-FEEDBACK step. Applies reviewer feedback, replies, files follow-ups, and pushes in autonomous mode, then returns the ccmagic status handshake with counts. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: sonnet
+skills:
+  - ccmagic:pr-feedback
+  - ccmagic:push
+tools: Read, Edit, Bash, Glob, Grep, Task
+---
+
+You are running the **pr-feedback** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `pr-feedback` procedure in autonomous mode** (triage → execute): apply address-now fixes, reply to declined/question threads, file one follow-up ticket per deferred/out-of-scope item, then push using the preloaded `push` procedure inline. Use the grounding block in your task prompt.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human` (a genuine reviewer tie), emit the handshake and stop; do not park the ticket yourself.
+
+Follow the preloaded procedures directly; do not re-invoke `/ccmagic:pr-feedback` or `/ccmagic:push` as skills.
+
+Return **only** the pr-feedback autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: applied {A} / declined {D} / deferred {F}   (or the blocking tie on needs-human)
+follow_ups: [<follow-up ticket ids filed>]
+```
+
+Grounding block (your task prompt):
+```

--- a/agents/auto-feedback.md
+++ b/agents/auto-feedback.md
@@ -5,7 +5,7 @@ model: sonnet
 skills:
   - ccmagic:pr-feedback
   - ccmagic:push
-tools: Read, Edit, Bash, Glob, Grep, Task
+disallowedTools: Skill
 ---
 
 You are running the **pr-feedback** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.

--- a/agents/auto-feedback.md
+++ b/agents/auto-feedback.md
@@ -24,5 +24,4 @@ reason: applied {A} / declined {D} / deferred {F}   (or the blocking tie on need
 follow_ups: [<follow-up ticket ids filed>]
 ```
 
-Grounding block (your task prompt):
-```
+The grounding block arrives as your task prompt — read the tracker / ticket / PR context and the needs-human config from it.

--- a/agents/auto-finish.md
+++ b/agents/auto-finish.md
@@ -1,0 +1,27 @@
+---
+name: auto-finish
+description: Autonomous-run FINISH step. Enforces the merge gate and merges (or returns needs-human) in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: sonnet
+skills:
+  - ccmagic:finish-ticket
+tools: Read, Edit, Bash, Glob, Grep
+---
+
+You are running the **finish** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `finish-ticket` procedure in autonomous mode**: enforce the merge gate (mergeable + CI green + no unaddressed change-requests), take the Done path, merge with the strategy the skill determines, and auto-resolve only trivial conflicts. Use the grounding block in your task prompt.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human` (gate not satisfied, or a business-logic conflict), do NOT merge and do NOT park the ticket yourself; emit the handshake and stop so the orchestrator routes it.
+
+Follow the preloaded procedure directly; do not re-invoke `/ccmagic:finish-ticket` as a skill.
+
+Return **only** the finish-ticket autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — "merged into {base}" on done; the blockers on needs-human>
+follow_ups: []
+```
+
+Grounding block (your task prompt):
+```

--- a/agents/auto-finish.md
+++ b/agents/auto-finish.md
@@ -4,7 +4,7 @@ description: Autonomous-run FINISH step. Enforces the merge gate and merges (or 
 model: sonnet
 skills:
   - ccmagic:finish-ticket
-tools: Read, Edit, Bash, Glob, Grep
+disallowedTools: Skill, Task
 ---
 
 You are running the **finish** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.

--- a/agents/auto-finish.md
+++ b/agents/auto-finish.md
@@ -23,5 +23,4 @@ reason: <one line — "merged into {base}" on done; the blockers on needs-human>
 follow_ups: []
 ```
 
-Grounding block (your task prompt):
-```
+The grounding block arrives as your task prompt — read the tracker / ticket / PR context and the needs-human config from it.

--- a/agents/auto-push.md
+++ b/agents/auto-push.md
@@ -23,5 +23,4 @@ reason: <one line — commits pushed on done; the blocking file/conflict on need
 follow_ups: []
 ```
 
-Grounding block (your task prompt):
-```
+The grounding block arrives as your task prompt — read the tracker / ticket / PR context and the needs-human config from it.

--- a/agents/auto-push.md
+++ b/agents/auto-push.md
@@ -1,6 +1,6 @@
 ---
 name: auto-push
-description: Autonomous-run PUSH step. Commits and pushes the working tree in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket when fork_steps is true. Not for direct human use.
+description: Autonomous-run PUSH step. Commits and pushes the working tree in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
 model: haiku
 skills:
   - ccmagic:push

--- a/agents/auto-push.md
+++ b/agents/auto-push.md
@@ -1,0 +1,27 @@
+---
+name: auto-push
+description: Autonomous-run PUSH step. Commits and pushes the working tree in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket when fork_steps is true. Not for direct human use.
+model: haiku
+skills:
+  - ccmagic:push
+tools: Read, Bash, Glob, Grep, Write
+---
+
+You are running the **push** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `push` skill procedure in autonomous mode**, using the grounding block in your task prompt below (it carries `autonomous: true`, the tracker/ticket/PR context, and the needs-human config). Do only the push: commit the working tree in logical groups and push. Never touch review, feedback, or merge.
+
+Because you were invoked with an autonomous grounding block from `auto-ticket`, you are **orchestrated** — on a `needs-human` outcome, do NOT park the ticket yourself; emit the handshake and stop so the orchestrator routes it.
+
+Follow the push skill's procedure directly using your Bash/git tools. Do not re-invoke `/ccmagic:push` as a skill.
+
+Return **only** the push autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — commits pushed on done; the blocking file/conflict on needs-human>
+follow_ups: []
+```
+
+Grounding block (your task prompt):
+```

--- a/agents/auto-review.md
+++ b/agents/auto-review.md
@@ -24,5 +24,4 @@ reason: <one line, when not clean>
 follow_ups: [<any tickets or deferrals noted>]
 ```
 
-Grounding block (your task prompt):
-```
+The grounding block arrives as your task prompt — read the tracker / ticket / PR context and the needs-human config from it.

--- a/agents/auto-review.md
+++ b/agents/auto-review.md
@@ -1,0 +1,28 @@
+---
+name: auto-review
+description: Autonomous-run REVIEW step. Runs the ticket-grounded code review in autonomous mode and returns the clean | fixable-findings | needs-human verdict. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: opus
+skills:
+  - ccmagic:review-ticket
+  - ccmagic:review
+tools: Read, Edit, Bash, Glob, Grep, Task
+---
+
+You are running the **review** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `review-ticket` procedure in autonomous mode**, which itself uses the preloaded `review` procedure — run `review`'s pipeline inline (spawn its parallel analysis subagents via your `Task` tool as `review` describes). Use the grounding block in your task prompt.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human`, emit the verdict and stop; do not park the ticket yourself. Report and verdict only; do not mutate code (the orchestrator applies fixes).
+
+Follow the preloaded procedures directly; do not re-invoke `/ccmagic:review-ticket` or `/ccmagic:review` as skills.
+
+Return **only** the review-ticket verdict handshake as the last thing in your output, verbatim:
+
+```
+status: clean | fixable-findings | needs-human
+reason: <one line, when not clean>
+follow_ups: [<any tickets or deferrals noted>]
+```
+
+Grounding block (your task prompt):
+```

--- a/agents/auto-review.md
+++ b/agents/auto-review.md
@@ -5,7 +5,7 @@ model: opus
 skills:
   - ccmagic:review-ticket
   - ccmagic:review
-tools: Read, Edit, Bash, Glob, Grep, Task
+disallowedTools: Skill
 ---
 
 You are running the **review** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.

--- a/agents/auto-validate.md
+++ b/agents/auto-validate.md
@@ -1,0 +1,25 @@
+---
+name: auto-validate
+description: Autonomous-run VALIDATE step. Runs pre-CI validation (lint/types/tests/build) and returns a done | needs-human handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: sonnet
+skills:
+  - ccmagic:validate
+tools: Read, Bash, Glob, Grep, Task
+---
+
+You are running the **validate** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `validate` procedure** to run the project's checks. Use the grounding block in your task prompt for context.
+
+Report the outcome as a handshake: `done` when validation passes; `needs-human` when it fails with a one-line summary of the failing checks (the orchestrator decides whether to fix-and-retry or park). Follow the preloaded procedure directly; do not re-invoke `/ccmagic:validate` as a skill.
+
+Return **only** this handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — "validation passed" on done; the failing checks on needs-human>
+follow_ups: []
+```
+
+Grounding block (your task prompt):
+```

--- a/agents/auto-validate.md
+++ b/agents/auto-validate.md
@@ -21,5 +21,4 @@ reason: <one line — "validation passed" on done; the failing checks on needs-h
 follow_ups: []
 ```
 
-Grounding block (your task prompt):
-```
+The grounding block arrives as your task prompt — read the tracker / ticket / PR context and the needs-human config from it.

--- a/agents/auto-work.md
+++ b/agents/auto-work.md
@@ -1,0 +1,28 @@
+---
+name: auto-work
+description: Autonomous-run WORK step. Implements a ticket end-to-end and opens the PR in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: opus
+skills:
+  - ccmagic:work-ticket
+  - ccmagic:debug
+tools: Read, Write, Edit, Bash, Glob, Grep, Task
+---
+
+You are running the **work** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `work-ticket` procedure in autonomous mode** (its "Autonomous mode" section), using the grounding block in your task prompt. For the Debugging path, follow the preloaded `debug` procedure inline. Implement, validate scope against the ticket, and open the PR.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human`, emit the handshake and stop; do not park the ticket yourself.
+
+Defer full code review to the orchestrator's dedicated review step — keep only work-ticket's lightweight self-check here (do not run a separate deep review). Follow the preloaded procedures directly; do not re-invoke `/ccmagic:work-ticket` or `/ccmagic:debug` as skills.
+
+Return **only** the work-ticket autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — the PR URL on done; the blocking decision on needs-human>
+follow_ups: [<any tickets or deferrals noted>]
+```
+
+Grounding block (your task prompt):
+```

--- a/agents/auto-work.md
+++ b/agents/auto-work.md
@@ -24,5 +24,4 @@ reason: <one line — the PR URL on done; the blocking decision on needs-human>
 follow_ups: [<any tickets or deferrals noted>]
 ```
 
-Grounding block (your task prompt):
-```
+The grounding block arrives as your task prompt — read the tracker / ticket / PR context and the needs-human config from it.

--- a/agents/auto-work.md
+++ b/agents/auto-work.md
@@ -5,7 +5,7 @@ model: opus
 skills:
   - ccmagic:work-ticket
   - ccmagic:debug
-tools: Read, Write, Edit, Bash, Glob, Grep, Task
+disallowedTools: Skill
 ---
 
 You are running the **work** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.

--- a/docs/auto-ticket-per-step-subagents-design.md
+++ b/docs/auto-ticket-per-step-subagents-design.md
@@ -29,6 +29,13 @@ Two upgrades address that:
 
   All overridable per repo. Strong models where a wrong call is expensive (implement, review); light models for mechanical steps (push).
 
+- **Skill-frontmatter model strategy (designs the clobber risk out at the source):** rather than rely solely on the preload-not-invoke trick, adjust the lifecycle skills' own `model:` so they never *disagree* with the step-agent's model:
+  - `work-ticket`, `review-ticket` → `model: inherit` (no pinned model to fight — inherits the step-agent's `opus` in autonomous, and the user's session model interactively).
+  - `push` → `model: haiku` (always trivial; cheap everywhere, interactive included).
+  - `pr-feedback`, `finish-ticket`, `validate` → keep `sonnet` (they already match their step-agent's `sonnet`).
+
+  After this, every step's skill model either *inherits* (nothing to clobber) or *matches* the step-agent — zero model conflicts — so per-step models are correct by construction and the preload trick becomes belt-and-suspenders. Tradeoff (accepted): this changes the interactive default for `work`/`review` (now scale to the session model) and `push` (now `haiku`); a `haiku` session would get a weaker interactive `work`/`review`, which is acceptable.
+
 ## Key mechanics (from Claude Code docs research)
 
 These three facts constrain the design:
@@ -110,7 +117,7 @@ Resolution for these keys follows the existing project → user → built-in pre
 
 ## Risks to validate during implementation
 
-1. **Skill-frontmatter model clobber (highest priority to smoke-test):** an invoked lifecycle skill declares its own `model:` (e.g. `work-ticket` → `sonnet`). The **preload-not-invoke** approach is specifically chosen to avoid the skill re-pinning the model, but this must be verified: spawn `auto-work` (opus), confirm the work actually runs on opus and isn't dropped to the skill's frontmatter model. If preload still clobbers, fall back to agent-frontmatter model as the source of truth and drop the invoke path.
+1. **Skill-frontmatter model clobber — now designed out (was highest priority):** originally the concern was that an invoked lifecycle skill's own `model: sonnet` would override the step-agent's chosen model. The skill-frontmatter model strategy above removes the disagreement at the source (skills `inherit` or already match the step-agent), so no step has a model to clobber. The preload-not-invoke approach remains as belt-and-suspenders. Nothing model-related needs a live smoke test now; the end-to-end test only confirms the fork + handshake plumbing.
 2. **Config-driven per-step override is best-effort** (the per-invocation `Task` model param is chosen by model reasoning, not a hard syntax). Treat **agent-frontmatter defaults as authoritative**; `model_<step>` overrides are a convenience layer. Document this expectation.
 3. **Nesting depth:** orchestrator (fork, depth 1) → step agent (Task, depth 2) → step's own Task fan-out (depth 3) stays within the depth-5 limit. Confirm no step pushes past it.
 

--- a/docs/auto-ticket-per-step-subagents-design.md
+++ b/docs/auto-ticket-per-step-subagents-design.md
@@ -1,6 +1,6 @@
 # Design: per-step subagents + per-step models for `auto-ticket`
 
-**Status:** approved design, pre-implementation
+**Status:** implemented in 3.2.0 — historical design record
 **Target version:** 3.2.0 (additive feature)
 **Branch:** `feature/auto-ticket-per-step-subagents`
 
@@ -52,7 +52,7 @@ These three facts constrain the design:
     │          build the grounding block (unchanged contract §2)
     │
     ├─ fork_steps: true  (default) → spawn each step as a child subagent (Task):
-    │     auto-work      (model: opus)    preloads work-ticket
+    │     auto-work      (model: opus)    preloads work-ticket + debug
     │     auto-review    (model: opus)    preloads review-ticket + review
     │     auto-feedback  (model: sonnet)  preloads pr-feedback + push
     │     auto-validate  (model: sonnet)  preloads validate
@@ -65,7 +65,7 @@ These three facts constrain the design:
           forked orchestrator's own context (today's flow, one level down).
 ```
 
-Each per-step agent is a **thin wrapper**: *"You are running the {step} step of an autonomous ticket run. Follow the preloaded {skill} procedure in autonomous mode with the grounding block below, then end with the handshake block."* The five lifecycle skills and their autonomous sections are **reused unchanged** — the agents only add model selection + context isolation.
+Each per-step agent is a **thin wrapper**: *"You are running the {step} step of an autonomous ticket run. Follow the preloaded {skill} procedure in autonomous mode with the grounding block below, then end with the handshake block."* The lifecycle skills and their autonomous sections are **reused unchanged in logic** (only three skills' `model:` line is tuned — see the model strategy) — the agents only add model selection + context isolation.
 
 > `push` shows up twice on purpose: `auto-feedback` **preloads** it because `pr-feedback` commits/pushes its own fixes internally (that push runs inline within the feedback step's model), while `auto-push` is the dedicated agent the orchestrator spawns for its *own* pushes (the Step 3 review-fix loop and Step 4b validate-fix). The `push → haiku` mapping refers to the dedicated `auto-push` step.
 
@@ -125,10 +125,14 @@ Resolution for these keys follows the existing project → user → built-in pre
 
 - No per-step *fork* granularity (global `fork_steps` only).
 - No backlog triage/selector (separate future skill; this design just stays compatible with one).
-- No change to any interactive path or to the five lifecycle skills' own frontmatter/behavior. This upgrade is purely additive and lives in the orchestrator + new agent wrappers.
+- No change to any interactive *logic*. The only frontmatter change is the `model:` line on three skills (`work-ticket`/`review-ticket` → `inherit`, `push` → `haiku`), which does affect their interactive default model. This upgrade is purely additive and lives in the orchestrator + new agent wrappers.
+
+## Known issue — `fork_steps: false` and fork-within-fork (PR review, pending live verification)
+
+`auto-ticket` is now unconditionally `context: fork`, so it runs as a subagent — and a subagent cannot invoke a `context: fork` skill via `Skill`. Several steps reach fork skills: `validate` *is* `context: fork`; `review-ticket` invokes `review` (fork); `work-ticket` invokes `review`/`analyze-impact` (fork). So on the `fork_steps: false` path those steps cannot run purely inline, and `fork_steps: false` does not reproduce the pre-3.2.0 flow regardless (the orchestrator is forked either way). Decision pending the live Linear smoke test (which reveals how fork→fork actually behaves): (a) redefine `fork_steps: false` as "inline where the skill has no fork dependency; `work`/`review`/`validate` keep their per-step agents", or (b) drop `fork_steps` and always fork per step. Until decided, shipped docs must not claim `fork_steps: false` restores the pre-3.2.0 flow.
 
 ## Backward compatibility
 
-- `fork_steps: false` reproduces 3.1.0 behavior (inline steps), so anyone who prefers the current flow keeps it with one line.
+- `fork_steps: false` runs steps inline in the orchestrator's own context — see *Known issue* above; the orchestrator itself still runs forked, so this does not reproduce the pre-3.2.0 flow.
 - All new config keys default to the shipped values; an untouched `.claude/ccmagic.local.md` gets the Balanced/forked defaults automatically.
-- The five lifecycle skills, their autonomous sections, and the handshake contract are unchanged.
+- The lifecycle skills' logic, their autonomous sections, and the handshake contract are unchanged; only three skills' `model:` line changed.

--- a/docs/auto-ticket-per-step-subagents-design.md
+++ b/docs/auto-ticket-per-step-subagents-design.md
@@ -1,0 +1,127 @@
+# Design: per-step subagents + per-step models for `auto-ticket`
+
+**Status:** approved design, pre-implementation
+**Target version:** 3.2.0 (additive feature)
+**Branch:** `feature/auto-ticket-per-step-subagents`
+
+## Problem
+
+`/ccmagic:auto-ticket` (shipped in 3.1.0) drives the ticket lifecycle by invoking each step **inline via the Skill tool** in one continuous context: `work-ticket → review-ticket → pr-feedback (looped) → finish-ticket`, with `push` and `validate` mixed in. Because everything runs in one context, a long unattended run accumulates the full implementation diff, review output, feedback loop, and CI-poll results in a single window — which leans on summarization and is heaviest exactly on the unattended/headless (Cyrus) path this feature targets.
+
+Two upgrades address that:
+
+1. **Per-step subagents** — run each lifecycle step in its own isolated subagent context so the orchestrator stays lean and each step gets a clean slate. Configurable, defaulting to forked.
+2. **Per-step models** — run the best-suited model per step (strong models where judgment matters, light models for mechanical steps), configurable per repo.
+
+## Decisions (locked)
+
+- **Fork config:** a single global toggle `fork_steps` (default `true`). `false` restores today's fully-inline behavior. No per-step fork granularity in v1 (YAGNI — can add later).
+- **Model mapping (Balanced, default):**
+
+  | Step | Default model |
+  |------|---------------|
+  | work-ticket | `opus` |
+  | review-ticket | `opus` |
+  | pr-feedback | `sonnet` |
+  | finish-ticket | `sonnet` |
+  | validate | `sonnet` |
+  | push | `haiku` |
+
+  All overridable per repo. Strong models where a wrong call is expensive (implement, review); light models for mechanical steps (push).
+
+## Key mechanics (from Claude Code docs research)
+
+These three facts constrain the design:
+
+1. **An inline skill cannot spawn subagents.** Only a skill running *as* a subagent may use the `Task` tool. → For the orchestrator to fan work out to per-step subagents, **`auto-ticket` must itself run forked** (`context: fork`). It already declares `Task(*)` in `allowed-tools`; it just can't use it until forked.
+2. **Per-step model is set on a per-step agent definition** (`agents/*.md` with a `model:` field). Subagent model resolution order: `CLAUDE_CODE_SUBAGENT_MODEL` env → per-invocation `Task` param → agent frontmatter `model:` → session model. → Agent frontmatter gives a **deterministic default**; a config value can be passed as a best-effort per-invocation override.
+3. **A forked skill cannot invoke another forked skill.** The existing lifecycle skills transitively call `context: fork` skills (`review`, `validate`). → Per-step agents **preload** the skills they need (agent `skills:` frontmatter injects skill *content* without invoking it) and run that procedure inline on their own model. This flattens the fork chain into one isolated, correctly-modeled context.
+
+## Architecture
+
+```
+/ccmagic:auto-ticket   (context: fork  ← now runs as a subagent)
+    │  Step 0: resolve tracker/ticket/config, read fork_steps + model_<step>,
+    │          build the grounding block (unchanged contract §2)
+    │
+    ├─ fork_steps: true  (default) → spawn each step as a child subagent (Task):
+    │     auto-work      (model: opus)    preloads work-ticket
+    │     auto-review    (model: opus)    preloads review-ticket + review
+    │     auto-feedback  (model: sonnet)  preloads pr-feedback + push
+    │     auto-validate  (model: sonnet)  preloads validate
+    │     auto-finish    (model: sonnet)  preloads finish-ticket
+    │     auto-push      (model: haiku)   preloads push
+    │        └ each child runs its step in autonomous mode and returns ONLY
+    │          its handshake block; the orchestrator parses the last block.
+    │
+    └─ fork_steps: false → run the steps inline via the Skill tool inside the
+          forked orchestrator's own context (today's flow, one level down).
+```
+
+Each per-step agent is a **thin wrapper**: *"You are running the {step} step of an autonomous ticket run. Follow the preloaded {skill} procedure in autonomous mode with the grounding block below, then end with the handshake block."* The five lifecycle skills and their autonomous sections are **reused unchanged** — the agents only add model selection + context isolation.
+
+> `push` shows up twice on purpose: `auto-feedback` **preloads** it because `pr-feedback` commits/pushes its own fixes internally (that push runs inline within the feedback step's model), while `auto-push` is the dedicated agent the orchestrator spawns for its *own* pushes (the Step 3 review-fix loop and Step 4b validate-fix). The `push → haiku` mapping refers to the dedicated `auto-push` step.
+
+### Data flow across the boundary
+
+- **In:** the orchestrator passes the grounding block (contract §2) as part of the `Task` prompt when spawning the child. Config overrides (`model_<step>`) are passed as the per-invocation model param (best-effort).
+- **Out:** the child's final response is returned to the orchestrator as text; the orchestrator parses the **last** handshake block (contract §3) exactly as it does for inline steps today. A child that returns no handshake is treated as `needs-human` (contract §3, unchanged).
+
+### Orchestrator step-execution mode
+
+`auto-ticket` gains a "step execution" helper concept: `run_step(step, grounding)` = *if `fork_steps` → spawn the step's agent via `Task` and parse the returned handshake; else → invoke the step's skill inline via `Skill` and parse its handshake.* Every existing orchestration decision (route-and-stop, the pr-feedback loop bounds, review-fix loop, CI polling) is unchanged — only *how a step is executed* changes.
+
+## Config surface (additive, all optional)
+
+```yaml
+# .claude/ccmagic.local.md
+fork_steps: true          # default — per-step subagents; false = inline (today)
+
+# Per-step model overrides (defaults live in the agent files):
+model_work_ticket:   opus
+model_review_ticket: opus
+model_pr_feedback:   sonnet
+model_finish_ticket: sonnet
+model_validate:      sonnet
+model_push:          haiku
+```
+
+Resolution for these keys follows the existing project → user → built-in precedence (contract §5). Defaults = the Balanced mapping, baked into the agent frontmatter; the `model_*` keys override best-effort at spawn time.
+
+## Files
+
+**New:**
+- `agents/auto-work.md`, `agents/auto-review.md`, `agents/auto-feedback.md`, `agents/auto-validate.md`, `agents/auto-finish.md`, `agents/auto-push.md` — thin per-step wrapper agents (frontmatter: `name`, `description`, `model`, `skills`, `tools`; body: run the preloaded step in autonomous mode + emit handshake).
+
+**Changed:**
+- `skills/auto-ticket/SKILL.md` — add `context: fork`; add a "Step execution mode" section (fork-via-Task vs inline) and the `run_step` helper concept; document config keys `fork_steps` + `model_<step>`; note the handshake now returns across the subagent boundary (format unchanged).
+- `skills/auto-ticket/autonomous-contract.md` — extend §5 config table with `fork_steps` + `model_<step>`; add a short "step execution" note.
+- `docs/ccmagic.local.md.example` — new keys + explainer.
+- `README.md` — Autonomous-mode section: note per-step subagents + per-step models and how to configure.
+- `CHANGELOG.md` — `[3.2.0]` entry.
+- `.claude-plugin/plugin.json` + `marketplace.json` — version → 3.2.0.
+
+## Behavior changes
+
+- `auto-ticket` becoming `context: fork` means the whole run executes in an isolated subagent; the main session receives the **returned run summary** rather than fully inline narration (progress still shows in the task pane). This is more aligned with the "keep context lean" goal, and `auto-ticket` is new (3.1.0) so there is no back-compat concern.
+- Because a subagent cannot invoke a `context: fork` skill, a **future backlog selector** must invoke `auto-ticket` from the main session, not from inside its own fork. Noted so we don't design that into a corner.
+- Inside a step subagent, any transitively-invoked `context: fork` skill (e.g. work-ticket → analyze-impact, review-ticket → review) runs **inline** within that step's isolated context rather than forking again. Preloading the needed skills on the agent makes this clean.
+- To avoid double-review, the orchestrated **work** step should defer full code review to the orchestrator's dedicated **review** step (it already runs `review-ticket` in Step 3); the work step keeps only its lightweight self-check.
+
+## Risks to validate during implementation
+
+1. **Skill-frontmatter model clobber (highest priority to smoke-test):** an invoked lifecycle skill declares its own `model:` (e.g. `work-ticket` → `sonnet`). The **preload-not-invoke** approach is specifically chosen to avoid the skill re-pinning the model, but this must be verified: spawn `auto-work` (opus), confirm the work actually runs on opus and isn't dropped to the skill's frontmatter model. If preload still clobbers, fall back to agent-frontmatter model as the source of truth and drop the invoke path.
+2. **Config-driven per-step override is best-effort** (the per-invocation `Task` model param is chosen by model reasoning, not a hard syntax). Treat **agent-frontmatter defaults as authoritative**; `model_<step>` overrides are a convenience layer. Document this expectation.
+3. **Nesting depth:** orchestrator (fork, depth 1) → step agent (Task, depth 2) → step's own Task fan-out (depth 3) stays within the depth-5 limit. Confirm no step pushes past it.
+
+## Non-goals (v1)
+
+- No per-step *fork* granularity (global `fork_steps` only).
+- No backlog triage/selector (separate future skill; this design just stays compatible with one).
+- No change to any interactive path or to the five lifecycle skills' own frontmatter/behavior. This upgrade is purely additive and lives in the orchestrator + new agent wrappers.
+
+## Backward compatibility
+
+- `fork_steps: false` reproduces 3.1.0 behavior (inline steps), so anyone who prefers the current flow keeps it with one line.
+- All new config keys default to the shipped values; an untouched `.claude/ccmagic.local.md` gets the Balanced/forked defaults automatically.
+- The five lifecycle skills, their autonomous sections, and the handshake contract are unchanged.

--- a/docs/auto-ticket-per-step-subagents-design.md
+++ b/docs/auto-ticket-per-step-subagents-design.md
@@ -15,7 +15,7 @@ Two upgrades address that:
 
 ## Decisions (locked)
 
-- **Fork config:** a single global toggle `fork_steps` (default `true`). `false` restores today's fully-inline behavior. No per-step fork granularity in v1 (YAGNI — can add later).
+- **Fork config:** dropped — `auto-ticket` always runs each step in its own forked subagent. (An earlier design had a `fork_steps` toggle with an inline mode, but a forked orchestrator can't invoke the `context: fork` skills `work`/`review`/`validate` reach, so the inline mode was unachievable.)
 - **Model mapping (Balanced, default):**
 
   | Step | Default model |
@@ -48,21 +48,18 @@ These three facts constrain the design:
 
 ```
 /ccmagic:auto-ticket   (context: fork  ← now runs as a subagent)
-    │  Step 0: resolve tracker/ticket/config, read fork_steps + model_<step>,
+    │  Step 0: resolve tracker/ticket/config, read model_<step>,
     │          build the grounding block (unchanged contract §2)
     │
-    ├─ fork_steps: true  (default) → spawn each step as a child subagent (Task):
-    │     auto-work      (model: opus)    preloads work-ticket + debug
-    │     auto-review    (model: opus)    preloads review-ticket + review
-    │     auto-feedback  (model: sonnet)  preloads pr-feedback + push
-    │     auto-validate  (model: sonnet)  preloads validate
-    │     auto-finish    (model: sonnet)  preloads finish-ticket
-    │     auto-push      (model: haiku)   preloads push
-    │        └ each child runs its step in autonomous mode and returns ONLY
-    │          its handshake block; the orchestrator parses the last block.
-    │
-    └─ fork_steps: false → run the steps inline via the Skill tool inside the
-          forked orchestrator's own context (today's flow, one level down).
+    └─ spawn each step as a child subagent (Task):
+          auto-work      (model: opus)    preloads work-ticket + debug
+          auto-review    (model: opus)    preloads review-ticket + review
+          auto-feedback  (model: sonnet)  preloads pr-feedback + push
+          auto-validate  (model: sonnet)  preloads validate
+          auto-finish    (model: sonnet)  preloads finish-ticket
+          auto-push      (model: haiku)   preloads push
+             └ each child runs its step in autonomous mode and returns ONLY
+               its handshake block; the orchestrator parses the last block.
 ```
 
 Each per-step agent is a **thin wrapper**: *"You are running the {step} step of an autonomous ticket run. Follow the preloaded {skill} procedure in autonomous mode with the grounding block below, then end with the handshake block."* The lifecycle skills and their autonomous sections are **reused unchanged in logic** (only three skills' `model:` line is tuned — see the model strategy) — the agents only add model selection + context isolation.
@@ -76,14 +73,12 @@ Each per-step agent is a **thin wrapper**: *"You are running the {step} step of 
 
 ### Orchestrator step-execution mode
 
-`auto-ticket` gains a "step execution" helper concept: `run_step(step, grounding)` = *if `fork_steps` → spawn the step's agent via `Task` and parse the returned handshake; else → invoke the step's skill inline via `Skill` and parse its handshake.* Every existing orchestration decision (route-and-stop, the pr-feedback loop bounds, review-fix loop, CI polling) is unchanged — only *how a step is executed* changes.
+`auto-ticket` gains a "step execution" helper concept: `run_step(step, grounding)` = *spawn the step's agent via `Task` and parse the returned handshake.* Every existing orchestration decision (route-and-stop, the pr-feedback loop bounds, review-fix loop, CI polling) is unchanged — only *how a step is executed* changes (from inline `Skill` invocation in 3.1.0 to a forked per-step subagent in 3.2.0).
 
 ## Config surface (additive, all optional)
 
 ```yaml
 # .claude/ccmagic.local.md
-fork_steps: true          # default — per-step subagents; false = inline (today)
-
 # Per-step model overrides (defaults live in the agent files):
 model_work_ticket:   opus
 model_review_ticket: opus
@@ -127,12 +122,14 @@ Resolution for these keys follows the existing project → user → built-in pre
 - No backlog triage/selector (separate future skill; this design just stays compatible with one).
 - No change to any interactive *logic*. The only frontmatter change is the `model:` line on three skills (`work-ticket`/`review-ticket` → `inherit`, `push` → `haiku`), which does affect their interactive default model. This upgrade is purely additive and lives in the orchestrator + new agent wrappers.
 
-## Known issue — `fork_steps: false` and fork-within-fork (PR review, pending live verification)
+## Resolved — fork_steps dropped
 
-`auto-ticket` is now unconditionally `context: fork`, so it runs as a subagent — and a subagent cannot invoke a `context: fork` skill via `Skill`. Several steps reach fork skills: `validate` *is* `context: fork`; `review-ticket` invokes `review` (fork); `work-ticket` invokes `review`/`analyze-impact` (fork). So on the `fork_steps: false` path those steps cannot run purely inline, and `fork_steps: false` does not reproduce the pre-3.2.0 flow regardless (the orchestrator is forked either way). Decision pending the live Linear smoke test (which reveals how fork→fork actually behaves): (a) redefine `fork_steps: false` as "inline where the skill has no fork dependency; `work`/`review`/`validate` keep their per-step agents", or (b) drop `fork_steps` and always fork per step. Until decided, shipped docs must not claim `fork_steps: false` restores the pre-3.2.0 flow.
+`auto-ticket` is unconditionally `context: fork`, so it runs as a subagent — and a subagent cannot invoke a `context: fork` skill via `Skill`. Several steps reach fork skills: `validate` *is* `context: fork`; `review-ticket` invokes `review` (fork); `work-ticket` invokes `review`/`analyze-impact` (fork). That meant the originally-designed `fork_steps: false` inline path could never purely inline those steps, and would not have reproduced the pre-3.2.0 flow regardless (the orchestrator is forked either way).
+
+This was resolved by dropping `fork_steps` entirely rather than picking between the two options considered at the time ("inline where the skill has no fork dependency" vs. "always fork per step") — `auto-ticket` now always forks each step to its per-step agent. This also matches the feature's actual purpose: per-step isolation and per-step models are the whole point, so an inline mode was never something worth preserving.
 
 ## Backward compatibility
 
-- `fork_steps: false` runs steps inline in the orchestrator's own context — see *Known issue* above; the orchestrator itself still runs forked, so this does not reproduce the pre-3.2.0 flow.
+- `fork_steps` was dropped — see *Resolved — fork_steps dropped* above. There is no inline mode; every step always runs forked to its per-step agent, and the orchestrator itself always runs forked.
 - All new config keys default to the shipped values; an untouched `.claude/ccmagic.local.md` gets the Balanced/forked defaults automatically.
 - The lifecycle skills' logic, their autonomous sections, and the handshake contract are unchanged; only three skills' `model:` line changed.

--- a/docs/auto-ticket-per-step-subagents-plan.md
+++ b/docs/auto-ticket-per-step-subagents-plan.md
@@ -1,7 +1,7 @@
 # auto-ticket Per-Step Subagents + Per-Step Models — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
-> **Status:** implemented in 3.2.0 — historical record. Tasks describe the incremental build (e.g. Task 1 wired only `push`; Task 3 wired the rest); the shipped skill routes all six steps.
+> **Status:** implemented in 3.2.0 — historical record. Tasks describe the incremental build (e.g. Task 1 wired only `push`; Task 3 wired the rest); the shipped skill routes all six steps. `fork_steps` was later dropped — the shipped skill always forks per step.
 
 **Goal:** Make `/ccmagic:auto-ticket` run each lifecycle step in its own forked subagent (configurable, default on) on a best-fit per-step model, reusing the five lifecycle skills unchanged.
 

--- a/docs/auto-ticket-per-step-subagents-plan.md
+++ b/docs/auto-ticket-per-step-subagents-plan.md
@@ -1,6 +1,7 @@
 # auto-ticket Per-Step Subagents + Per-Step Models — Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status:** implemented in 3.2.0 — historical record. Tasks describe the incremental build (e.g. Task 1 wired only `push`; Task 3 wired the rest); the shipped skill routes all six steps.
 
 **Goal:** Make `/ccmagic:auto-ticket` run each lifecycle step in its own forked subagent (configurable, default on) on a best-fit per-step model, reusing the five lifecycle skills unchanged.
 
@@ -123,7 +124,7 @@ Run:
 ```bash
 cd /Users/devon/git/ccmagic
 python3 -c "import yaml,pathlib; print('fm ok:', yaml.safe_load(pathlib.Path('skills/auto-ticket/SKILL.md').read_text().split('---')[1])['context'])"
-c=$(grep -c '```' skills/auto-ticket/SKILL.md); echo "fences: $c $([ $((c%2)) -eq 0 ] && echo OK || echo ODD)"
+c=$(grep -cE '`{3}' skills/auto-ticket/SKILL.md); echo "fences: $c $([ $((c%2)) -eq 0 ] && echo OK || echo ODD)"
 ```
 Expected: `fm ok: fork` and `fences: <even> OK`.
 

--- a/docs/auto-ticket-per-step-subagents-plan.md
+++ b/docs/auto-ticket-per-step-subagents-plan.md
@@ -1,0 +1,619 @@
+# auto-ticket Per-Step Subagents + Per-Step Models — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/ccmagic:auto-ticket` run each lifecycle step in its own forked subagent (configurable, default on) on a best-fit per-step model, reusing the five lifecycle skills unchanged.
+
+**Architecture:** `auto-ticket` becomes `context: fork` so it can spawn subagents. Six thin per-step wrapper agents in `agents/` each **preload** their lifecycle skill and run it in autonomous mode on their own `model:`, returning only the status handshake. A `fork_steps` toggle chooses per-step subagents (default) vs today's inline flow; `model_<step>` keys override the defaults.
+
+**Tech Stack:** Claude Code plugin — Markdown SKILL/agent files with YAML frontmatter, `Task`/`Skill` tools, bash verification. No compiled code, no unit-test harness; "tests" are structural validators + a local plugin load-test + one interactive end-to-end smoke test.
+
+## Global Constraints
+
+- **Additive & opt-in:** no interactive path and none of the five lifecycle skills' frontmatter/behavior may change. All new behavior gated behind `fork_steps` / `model_<step>` / the autonomous signal.
+- **Handshake contract unchanged:** steps still end with the `status: clean | fixable-findings | needs-human | done` fenced block (contract §3); it now returns across the subagent boundary. A missing handshake = `needs-human`.
+- **Config precedence:** new keys resolve project `.claude/ccmagic.local.md` → user `~/.claude/ccmagic.local.md` → built-in default (contract §5).
+- **Balanced model mapping (defaults):** work-ticket→`opus`, review-ticket→`opus`, pr-feedback→`sonnet`, finish-ticket→`sonnet`, validate→`sonnet`, push→`haiku`.
+- **Model aliases only** (`opus`/`sonnet`/`haiku`/`inherit`) — never pin full model IDs, for portability.
+- **Model safety rule:** per-step agents run their step by following the **preloaded** skill content directly; they do **not** carry the `Skill` tool for the primary step (re-invoking a skill would re-pin that skill's own `model:` frontmatter and defeat per-step model selection).
+- **Version target:** 3.2.0. Branch: `feature/auto-ticket-per-step-subagents`. Spec: `docs/auto-ticket-per-step-subagents-design.md`.
+
+---
+
+### Task 1: Fork mechanic proof-of-concept on the `push` step
+
+De-risk the linchpin (model-per-subagent + handshake return) on the cheapest step before building the rest. Delivers a working forked `push` step; other steps stay inline until Task 3.
+
+**Files:**
+- Create: `agents/auto-push.md`
+- Modify: `skills/auto-ticket/SKILL.md` (add `context: fork`; add a minimal "Step execution mode" section that routes only `push` through its agent when `fork_steps` is true)
+
+**Interfaces:**
+- Produces: agent `auto-push` (spawned via `Task` by name), model `haiku`, preloads `ccmagic:push`, returns the push handshake block.
+- Consumes: the grounding block (contract §2), passed as the `Task` prompt.
+
+- [ ] **Step 1: Create `agents/auto-push.md`**
+
+```markdown
+---
+name: auto-push
+description: Autonomous-run PUSH step. Commits and pushes the working tree in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket when fork_steps is true. Not for direct human use.
+model: haiku
+skills:
+  - ccmagic:push
+tools: Read, Bash, Glob, Grep, Write
+---
+
+You are running the **push** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `push` skill procedure in autonomous mode**, using the grounding block in your task prompt below (it carries `autonomous: true`, the tracker/ticket/PR context, and the needs-human config). Do only the push: commit the working tree in logical groups and push. Never touch review, feedback, or merge.
+
+Because you were invoked with an autonomous grounding block from `auto-ticket`, you are **orchestrated** — on a `needs-human` outcome, do NOT park the ticket yourself; emit the handshake and stop so the orchestrator routes it.
+
+Follow the push skill's procedure directly using your Bash/git tools. Do not re-invoke `/ccmagic:push` as a skill.
+
+Return **only** the push autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — commits pushed on done; the blocking file/conflict on needs-human>
+follow_ups: []
+```
+
+Grounding block (your task prompt):
+```
+
+- [ ] **Step 2: Verify the agent frontmatter parses and has the required fields**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+python3 - <<'PY'
+import yaml, pathlib
+raw = pathlib.Path("agents/auto-push.md").read_text().split("---")[1]
+fm = yaml.safe_load(raw)
+assert fm["name"] == "auto-push", fm
+assert fm["model"] == "haiku", fm
+assert fm["skills"] == ["ccmagic:push"], fm
+assert "Skill" not in str(fm.get("tools","")), "push agent must not carry the Skill tool"
+print("auto-push frontmatter OK:", fm)
+PY
+```
+Expected: `auto-push frontmatter OK: {...}` and no assertion error.
+
+- [ ] **Step 3: Add `context: fork` to `auto-ticket` frontmatter**
+
+Modify `skills/auto-ticket/SKILL.md` frontmatter — add one line after `model: sonnet`:
+```yaml
+context: fork
+```
+
+- [ ] **Step 4: Add the minimal "Step execution mode" section to `auto-ticket`**
+
+Insert this section immediately after the `## The contract` section in `skills/auto-ticket/SKILL.md`:
+
+```markdown
+## Step execution mode
+
+`auto-ticket` runs **forked** (`context: fork`), so it executes as a subagent and can spawn a child subagent per step. How each step below runs is decided by `fork_steps` (config, default `true`):
+
+- **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
+- **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (the 3.1.0 behavior, one level down).
+
+Call this `run_step(step, grounding)`. **Every "Invoke `/ccmagic:<skill>`" instruction in the steps below goes through `run_step`** — nothing else about the flow (route-and-stop, loops, bounds) changes.
+
+### Per-step agent registry
+
+| Step | Agent | Default model | Config override |
+|------|-------|---------------|-----------------|
+| work-ticket | `auto-work` | `opus` | `model_work_ticket` |
+| review-ticket | `auto-review` | `opus` | `model_review_ticket` |
+| pr-feedback | `auto-feedback` | `sonnet` | `model_pr_feedback` |
+| validate | `auto-validate` | `sonnet` | `model_validate` |
+| finish-ticket | `auto-finish` | `sonnet` | `model_finish_ticket` |
+| push | `auto-push` | `haiku` | `model_push` |
+
+Model resolution per step: the agent's frontmatter `model:` is the authoritative default; if a `model_<step>` config value is set, pass it as the `Task` per-invocation model override (best-effort). Only `push` is wired in this iteration; the rest are added in a later change.
+```
+
+- [ ] **Step 5: Verify the skill still has valid frontmatter and balanced fences**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+python3 -c "import yaml,pathlib; print('fm ok:', yaml.safe_load(pathlib.Path('skills/auto-ticket/SKILL.md').read_text().split('---')[1])['context'])"
+c=$(grep -c '```' skills/auto-ticket/SKILL.md); echo "fences: $c $([ $((c%2)) -eq 0 ] && echo OK || echo ODD)"
+```
+Expected: `fm ok: fork` and `fences: <even> OK`.
+
+- [ ] **Step 6: Interactive smoke test — the linchpin**
+
+This is the decision gate; it needs a real run in the Claude Code UI (model identity per subagent is not introspectable from inside a skill).
+
+In a repo wired to a tracker (e.g. the MagicMenu repo with the Linear MCP), with `fork_steps: true` in `.claude/ccmagic.local.md`, drive a run that reaches the push step and confirm in the **task pane**:
+1. A child subagent (`auto-push`) is spawned for the push step (not run inline).
+2. Its model shows as **haiku** — i.e. `push`'s own `model:` frontmatter did **not** clobber it (validates spec risk #1).
+3. The child returns a `status: …` handshake block the orchestrator parses.
+4. Set `fork_steps: false` and confirm push then runs **inline** (no child spawned).
+
+**Gate:** If the model is clobbered to `push`'s frontmatter value, apply spec risk-#1 fallback before Task 2: keep the agent-frontmatter model authoritative and confirm the agent is following the *preloaded* procedure (never invoking `/ccmagic:push` via `Skill`). Do not proceed to Task 2 until 1–4 hold.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add agents/auto-push.md skills/auto-ticket/SKILL.md
+git commit -m "feat(auto-ticket): fork the push step via per-step agent (PoC)"
+```
+
+---
+
+### Task 2: Create the remaining five per-step agents
+
+**Files:**
+- Create: `agents/auto-work.md`, `agents/auto-review.md`, `agents/auto-feedback.md`, `agents/auto-validate.md`, `agents/auto-finish.md`
+
+**Interfaces:**
+- Produces: agents `auto-work` (opus), `auto-review` (opus), `auto-feedback` (sonnet), `auto-validate` (sonnet), `auto-finish` (sonnet), each spawned by name via `Task`, each returning its lifecycle skill's handshake.
+
+- [ ] **Step 1: Create `agents/auto-work.md`**
+
+```markdown
+---
+name: auto-work
+description: Autonomous-run WORK step. Implements a ticket end-to-end and opens the PR in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: opus
+skills:
+  - ccmagic:work-ticket
+  - ccmagic:debug
+tools: Read, Write, Edit, Bash, Glob, Grep, Task
+---
+
+You are running the **work** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `work-ticket` procedure in autonomous mode** (its "Autonomous mode" section), using the grounding block in your task prompt. For the Debugging path, follow the preloaded `debug` procedure inline. Implement, validate scope against the ticket, and open the PR.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human`, emit the handshake and stop; do not park the ticket yourself.
+
+Defer full code review to the orchestrator's dedicated review step — keep only work-ticket's lightweight self-check here (do not run a separate deep review). Follow the preloaded procedures directly; do not re-invoke `/ccmagic:work-ticket` or `/ccmagic:debug` as skills.
+
+Return **only** the work-ticket autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — the PR URL on done; the blocking decision on needs-human>
+follow_ups: [<any tickets or deferrals noted>]
+```
+
+Grounding block (your task prompt):
+```
+
+- [ ] **Step 2: Create `agents/auto-review.md`**
+
+```markdown
+---
+name: auto-review
+description: Autonomous-run REVIEW step. Runs the ticket-grounded code review in autonomous mode and returns the clean | fixable-findings | needs-human verdict. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: opus
+skills:
+  - ccmagic:review-ticket
+  - ccmagic:review
+tools: Read, Edit, Bash, Glob, Grep, Task
+---
+
+You are running the **review** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `review-ticket` procedure in autonomous mode**, which itself uses the preloaded `review` procedure — run `review`'s pipeline inline (spawn its parallel analysis subagents via your `Task` tool as `review` describes). Use the grounding block in your task prompt.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human`, emit the verdict and stop; do not park the ticket yourself. Report and verdict only; do not mutate code (the orchestrator applies fixes).
+
+Follow the preloaded procedures directly; do not re-invoke `/ccmagic:review-ticket` or `/ccmagic:review` as skills.
+
+Return **only** the review-ticket verdict handshake as the last thing in your output, verbatim:
+
+```
+status: clean | fixable-findings | needs-human
+reason: <one line, when not clean>
+follow_ups: [<any tickets or deferrals noted>]
+```
+
+Grounding block (your task prompt):
+```
+
+- [ ] **Step 3: Create `agents/auto-feedback.md`**
+
+```markdown
+---
+name: auto-feedback
+description: Autonomous-run PR-FEEDBACK step. Applies reviewer feedback, replies, files follow-ups, and pushes in autonomous mode, then returns the ccmagic status handshake with counts. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: sonnet
+skills:
+  - ccmagic:pr-feedback
+  - ccmagic:push
+tools: Read, Edit, Bash, Glob, Grep, Task
+---
+
+You are running the **pr-feedback** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `pr-feedback` procedure in autonomous mode** (triage → execute): apply address-now fixes, reply to declined/question threads, file one follow-up ticket per deferred/out-of-scope item, then push using the preloaded `push` procedure inline. Use the grounding block in your task prompt.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human` (a genuine reviewer tie), emit the handshake and stop; do not park the ticket yourself.
+
+Follow the preloaded procedures directly; do not re-invoke `/ccmagic:pr-feedback` or `/ccmagic:push` as skills.
+
+Return **only** the pr-feedback autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: applied {A} / declined {D} / deferred {F}   (or the blocking tie on needs-human)
+follow_ups: [<follow-up ticket ids filed>]
+```
+
+Grounding block (your task prompt):
+```
+
+- [ ] **Step 4: Create `agents/auto-validate.md`**
+
+```markdown
+---
+name: auto-validate
+description: Autonomous-run VALIDATE step. Runs pre-CI validation (lint/types/tests/build) and returns a done | needs-human handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: sonnet
+skills:
+  - ccmagic:validate
+tools: Read, Bash, Glob, Grep, Task
+---
+
+You are running the **validate** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `validate` procedure** to run the project's checks. Use the grounding block in your task prompt for context.
+
+Report the outcome as a handshake: `done` when validation passes; `needs-human` when it fails with a one-line summary of the failing checks (the orchestrator decides whether to fix-and-retry or park). Follow the preloaded procedure directly; do not re-invoke `/ccmagic:validate` as a skill.
+
+Return **only** this handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — "validation passed" on done; the failing checks on needs-human>
+follow_ups: []
+```
+
+Grounding block (your task prompt):
+```
+
+- [ ] **Step 5: Create `agents/auto-finish.md`**
+
+```markdown
+---
+name: auto-finish
+description: Autonomous-run FINISH step. Enforces the merge gate and merges (or returns needs-human) in autonomous mode, then returns the ccmagic status handshake. Spawned by /ccmagic:auto-ticket. Not for direct human use.
+model: sonnet
+skills:
+  - ccmagic:finish-ticket
+tools: Read, Edit, Bash, Glob, Grep
+---
+
+You are running the **finish** step of an autonomous ticket run driven by `/ccmagic:auto-ticket`.
+
+Follow the **preloaded `finish-ticket` procedure in autonomous mode**: enforce the merge gate (mergeable + CI green + no unaddressed change-requests), take the Done path, merge with the strategy the skill determines, and auto-resolve only trivial conflicts. Use the grounding block in your task prompt.
+
+Because you were invoked with an autonomous grounding block, you are **orchestrated** — on `needs-human` (gate not satisfied, or a business-logic conflict), do NOT merge and do NOT park the ticket yourself; emit the handshake and stop so the orchestrator routes it.
+
+Follow the preloaded procedure directly; do not re-invoke `/ccmagic:finish-ticket` as a skill.
+
+Return **only** the finish-ticket autonomous handshake as the last thing in your output, verbatim:
+
+```
+status: done | needs-human
+reason: <one line — "merged into {base}" on done; the blockers on needs-human>
+follow_ups: []
+```
+
+Grounding block (your task prompt):
+```
+
+- [ ] **Step 6: Verify all six agents parse, carry the right model, and (except review/feedback/work which legitimately fan out) omit the Skill tool**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+python3 - <<'PY'
+import yaml, pathlib
+want = {"auto-work":"opus","auto-review":"opus","auto-feedback":"sonnet",
+        "auto-validate":"sonnet","auto-finish":"sonnet","auto-push":"haiku"}
+for name, model in want.items():
+    fm = yaml.safe_load(pathlib.Path(f"agents/{name}.md").read_text().split("---")[1])
+    assert fm["name"] == name, (name, fm)
+    assert fm["model"] == model, (name, fm["model"], "want", model)
+    assert "Skill" not in str(fm.get("tools","")), f"{name} must not carry the Skill tool"
+    assert fm.get("skills"), f"{name} must preload its skill(s)"
+print("all six agents OK:", list(want))
+PY
+```
+Expected: `all six agents OK: [...]` with no assertion error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add agents/auto-work.md agents/auto-review.md agents/auto-feedback.md agents/auto-validate.md agents/auto-finish.md
+git commit -m "feat(auto-ticket): add per-step wrapper agents for work/review/feedback/validate/finish"
+```
+
+---
+
+### Task 3: Wire all steps through `run_step` + config loading
+
+**Files:**
+- Modify: `skills/auto-ticket/SKILL.md` (generalize Step execution mode to all steps; extend Step 0 config load with `fork_steps` + `model_<step>`)
+
+**Interfaces:**
+- Consumes: all six agents from Tasks 1–2.
+- Produces: full fork/inline routing for every step; config keys `fork_steps`, `model_work_ticket`, `model_review_ticket`, `model_pr_feedback`, `model_finish_ticket`, `model_validate`, `model_push`.
+
+- [ ] **Step 1: Update the registry note to cover all steps**
+
+In `skills/auto-ticket/SKILL.md`, replace the final sentence of the "Per-step agent registry" subsection ("Only `push` is wired in this iteration; the rest are added in a later change.") with:
+```markdown
+All six steps route through `run_step`. When `fork_steps` is false, every step falls back to an inline `Skill` invocation in this orchestrator's context.
+```
+
+- [ ] **Step 2: Extend Step 0 config loading**
+
+In `skills/auto-ticket/SKILL.md`, in Step 0 item 3 ("Load config"), append to the keys list:
+```markdown
+, `fork_steps` (bool, default `true`), and the per-step model overrides `model_work_ticket`, `model_review_ticket`, `model_pr_feedback`, `model_finish_ticket`, `model_validate`, `model_push` (each defaulting to the registry value)
+```
+
+- [ ] **Step 3: Point each step invocation at `run_step`**
+
+In `skills/auto-ticket/SKILL.md`, for each step (Step 1 work, Step 3 review, Step 4a pr-feedback, Step 4b validate, Step 5 finish, and the Step 3/4 push commits), ensure the invocation reads "run the {step} step via `run_step`" rather than a bare "Invoke `/ccmagic:<skill>`". Add this sentence once at the top of Step 1:
+```markdown
+> Each step below is executed via `run_step` (see *Step execution mode*): forked to its per-step agent when `fork_steps` is true, inline otherwise. The grounding block and handshake parsing are identical either way.
+```
+
+- [ ] **Step 4: Verify the wiring references every agent and config key**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+for a in auto-work auto-review auto-feedback auto-validate auto-finish auto-push; do
+  grep -q "$a" skills/auto-ticket/SKILL.md && echo "ref $a: OK" || echo "ref $a: MISSING"
+done
+for k in fork_steps model_work_ticket model_review_ticket model_pr_feedback model_finish_ticket model_validate model_push; do
+  grep -q "$k" skills/auto-ticket/SKILL.md && echo "key $k: OK" || echo "key $k: MISSING"
+done
+```
+Expected: every line ends `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add skills/auto-ticket/SKILL.md
+git commit -m "feat(auto-ticket): route every step through run_step with per-step models"
+```
+
+---
+
+### Task 4: Update the autonomous contract
+
+**Files:**
+- Modify: `skills/auto-ticket/autonomous-contract.md`
+
+- [ ] **Step 1: Extend the §5 config table**
+
+Add these rows to the §5 "Config keys" table in `skills/auto-ticket/autonomous-contract.md`:
+```markdown
+| `fork_steps` | bool | `true` | Run each lifecycle step in its own forked subagent; `false` runs them inline in the orchestrator. |
+| `model_work_ticket` | string | `opus` | Model for the work step's agent (`auto-work`). |
+| `model_review_ticket` | string | `opus` | Model for the review step's agent (`auto-review`). |
+| `model_pr_feedback` | string | `sonnet` | Model for the pr-feedback step's agent (`auto-feedback`). |
+| `model_finish_ticket` | string | `sonnet` | Model for the finish step's agent (`auto-finish`). |
+| `model_validate` | string | `sonnet` | Model for the validate step's agent (`auto-validate`). |
+| `model_push` | string | `haiku` | Model for the push step's agent (`auto-push`). |
+```
+
+- [ ] **Step 2: Add a "step execution" note after §2**
+
+Add this paragraph at the end of §2 (The grounding block) in `autonomous-contract.md`:
+```markdown
+When `fork_steps` is true, `auto-ticket` runs each step in a per-step subagent (`agents/auto-*.md`) on the step's model, passing this grounding block as the child's task prompt and reading back the child's handshake (§3). The child agents preload their lifecycle skill rather than invoking it, so the step runs on the agent's model. With `fork_steps: false`, steps run inline via the `Skill` tool. Either way the grounding block and handshake are identical.
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+grep -c 'fork_steps\|model_work_ticket\|model_push' skills/auto-ticket/autonomous-contract.md
+c=$(grep -c '```' skills/auto-ticket/autonomous-contract.md); echo "fences: $([ $((c%2)) -eq 0 ] && echo OK || echo ODD)"
+```
+Expected: a count ≥ 3 and `fences: OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add skills/auto-ticket/autonomous-contract.md
+git commit -m "docs(auto-ticket): document fork_steps + per-step model keys in the contract"
+```
+
+---
+
+### Task 5: Update user-facing docs (config example + README)
+
+**Files:**
+- Modify: `docs/ccmagic.local.md.example`, `README.md`
+
+- [ ] **Step 1: Add the keys to the config example frontmatter**
+
+In `docs/ccmagic.local.md.example`, after the `max_feedback_passes` block (before the closing `---`), add:
+```yaml
+# --- Per-step execution (used by /ccmagic:auto-ticket) ---
+# Run each lifecycle step in its own forked subagent (default true). Set false
+# to run every step inline in one context (the 3.1.0 behavior).
+fork_steps: true
+# Per-step model (defaults shown = the Balanced mapping; set only to override):
+# model_work_ticket:   opus
+# model_review_ticket: opus
+# model_pr_feedback:   sonnet
+# model_finish_ticket: sonnet
+# model_validate:      sonnet
+# model_push:          haiku
+```
+
+- [ ] **Step 2: Add the keys to the "Recognized keys" table**
+
+In `docs/ccmagic.local.md.example`, add to the recognized-keys table:
+```markdown
+| `fork_steps` | Run each `auto-ticket` step in its own forked subagent. | `true` |
+| `model_<step>` | Per-step model override (`model_work_ticket` … `model_push`). | Balanced mapping |
+```
+
+- [ ] **Step 3: Extend the README Autonomous-mode section**
+
+In `README.md`, in the "Autonomous mode" section (after the config YAML block), add:
+```markdown
+### Per-step subagents and models
+
+By default `auto-ticket` runs each lifecycle step in its own **forked subagent** on a best-fit **model** — strong models where judgment matters, light ones for mechanical steps — which keeps the orchestrator's context lean on long unattended runs and puts the right model on each step:
+
+| Step | Default model |
+|---|---|
+| work-ticket / review-ticket | `opus` |
+| pr-feedback / finish-ticket / validate | `sonnet` |
+| push | `haiku` |
+
+Set `fork_steps: false` to run every step inline in one context instead, or override any step with `model_<step>` (e.g. `model_pr_feedback: opus`).
+```
+
+- [ ] **Step 4: Verify**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+grep -q 'fork_steps' docs/ccmagic.local.md.example && echo "example: OK"
+grep -q 'Per-step subagents and models' README.md && echo "readme: OK"
+```
+Expected: `example: OK` and `readme: OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add docs/ccmagic.local.md.example README.md
+git commit -m "docs: document fork_steps + per-step models for auto-ticket"
+```
+
+---
+
+### Task 6: CHANGELOG + version bump to 3.2.0
+
+**Files:**
+- Modify: `CHANGELOG.md`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Insert above the `## [3.1.0]` heading in `CHANGELOG.md`:
+```markdown
+## [3.2.0] — 2026-07
+
+### Added
+
+- **Per-step subagents for `/ccmagic:auto-ticket`** — each lifecycle step (work / review / pr-feedback / validate / finish / push) now runs in its own forked subagent on a best-fit model, keeping the orchestrator's context lean on long unattended runs. New thin wrapper agents live in `agents/auto-*.md`; the five lifecycle skills are reused unchanged. Configurable via `fork_steps` (default `true`; `false` restores the 3.1.0 inline flow).
+- **Per-step model selection** — Balanced defaults (`opus` for work/review, `sonnet` for pr-feedback/finish/validate, `haiku` for push), overridable per repo with `model_<step>` keys. `auto-ticket` itself is now `context: fork`.
+
+### Changed
+
+- **`skills/auto-ticket/SKILL.md`** — now `context: fork`; every step routes through a `run_step` helper (forked-per-step or inline). The handshake contract is unchanged; it now returns across the subagent boundary.
+```
+
+- [ ] **Step 2: Bump the version in both manifests**
+
+Change `"version": "3.1.0"` to `"version": "3.2.0"` in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+
+- [ ] **Step 3: Verify version + JSON validity**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+python3 -c "import json;a=json.load(open('.claude-plugin/plugin.json'));b=json.load(open('.claude-plugin/marketplace.json'));assert a['version']=='3.2.0' and b['plugins'][0]['version']=='3.2.0';print('versions 3.2.0 OK')"
+grep -m1 '^## \[' CHANGELOG.md
+```
+Expected: `versions 3.2.0 OK` and `## [3.2.0] — 2026-07`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add CHANGELOG.md .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore: document per-step subagents; bump to 3.2.0"
+```
+
+---
+
+### Task 7: Full structural sweep + end-to-end smoke test
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Structural sweep**
+
+Run:
+```bash
+cd /Users/devon/git/ccmagic
+echo "agents:"; ls agents/*.md | wc -l
+echo "skills:"; find skills -name SKILL.md | wc -l
+for f in skills/auto-ticket/SKILL.md skills/auto-ticket/autonomous-contract.md; do
+  c=$(grep -c '```' "$f"); echo "$f fences: $([ $((c%2)) -eq 0 ] && echo OK || echo ODD)"
+done
+python3 - <<'PY'
+import yaml, pathlib, glob
+for p in glob.glob("agents/*.md"):
+    yaml.safe_load(pathlib.Path(p).read_text().split("---")[1])
+print("all agent frontmatter parses")
+PY
+```
+Expected: `agents: 6`, `skills: 24`, both fences `OK`, `all agent frontmatter parses`.
+
+- [ ] **Step 2: Local plugin load-test**
+
+Run `claude --plugin-dir ./` and confirm: `/ccmagic:auto-ticket` loads, and the six `auto-*` agents are listed as available agents. (Manual — no assertion; confirm no load errors.)
+
+- [ ] **Step 3: End-to-end smoke test (interactive, real ticket)**
+
+In the MagicMenu repo (Linear MCP connected), with `.claude/ccmagic.local.md` set to `tracker: linear`, `fork_steps: true`, `needs_human_label: needs-human`:
+1. Run `/ccmagic:auto-ticket MM-305` (the test-only ticket — safest happy path).
+2. In the task pane, confirm each step spawns its `auto-*` child subagent on the mapped model (work/review on opus, feedback/validate/finish on sonnet, push on haiku).
+3. Confirm each child returns a handshake the orchestrator parses, and the run ends **merged** or **parked** (never hung).
+4. Re-run with `fork_steps: false` and confirm steps run inline (no child subagents), same outcome.
+5. Optionally run `/ccmagic:auto-ticket ENG-31` and confirm it **parks** (too large → needs-human) without merging.
+
+- [ ] **Step 4: Final commit (if the smoke test required tweaks)**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add -A && git commit -m "fix(auto-ticket): smoke-test adjustments for per-step subagents" || echo "no changes"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Per-step subagents (fork) → Tasks 1–3. ✓
+- `fork_steps` global toggle default true → Task 1 (section), Task 3 (all steps), Task 5 (docs). ✓
+- Per-step Balanced models + `model_<step>` overrides → Task 2 (agent frontmatter), Task 3 (config), Task 4/5 (docs). ✓
+- `auto-ticket` → `context: fork` → Task 1 Step 3. ✓
+- Preload-not-invoke model safety → agent bodies (Tasks 1–2) + Global Constraints. ✓
+- Handshake unchanged, crosses boundary → Task 1 section, Task 4 note. ✓
+- Contract §5 + step-execution note → Task 4. ✓
+- Config example + README + CHANGELOG + version → Tasks 5–6. ✓
+- Risk #1 (model clobber) validated early → Task 1 Step 6 gate. ✓
+- Risk #2 (best-effort override) → Task 1 registry note + Global Constraints. ✓
+- Behavior change (fork output = returned summary) → covered by run itself; documented in README/CHANGELOG. ✓
+- Non-goals (no per-step fork granularity, no selector, no interactive change) → Global Constraints + additive-only edits. ✓
+
+**2. Placeholder scan:** Agent bodies and edits carry actual content; `{A}/{D}/{F}`, `{base}`, `{step}` are the handshake/template tokens copied verbatim from the existing skills, not plan placeholders. No TBD/TODO.
+
+**3. Type consistency:** Agent names (`auto-work`/`auto-review`/`auto-feedback`/`auto-validate`/`auto-finish`/`auto-push`), config keys (`fork_steps`, `model_<step>`), and default models are identical across the registry (Task 1), agent frontmatter (Tasks 1–2), config load (Task 3), contract (Task 4), docs (Task 5), and verification greps. ✓

--- a/docs/auto-ticket-per-step-subagents-plan.md
+++ b/docs/auto-ticket-per-step-subagents-plan.md
@@ -100,7 +100,7 @@ Insert this section immediately after the `## The contract` section in `skills/a
 - **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
 - **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (the 3.1.0 behavior, one level down).
 
-Call this `run_step(step, grounding)`. **Every "Invoke `/ccmagic:<skill>`" instruction in the steps below goes through `run_step`** — nothing else about the flow (route-and-stop, loops, bounds) changes.
+Call this `run_step(step, grounding)`. In this iteration only the **push** step routes through `run_step`: run the `/ccmagic:push` commit-and-push call sites (in the Step 3 review-fix loop and Step 4b validate-fix) via `run_step` — forked to the `auto-push` agent when `fork_steps` is true, inline via `Skill` otherwise. All other steps continue to run inline as in 3.1.0; a later change routes them too. Nothing else about the flow (route-and-stop, loops, bounds) changes.
 
 ### Per-step agent registry
 

--- a/docs/auto-ticket-per-step-subagents-plan.md
+++ b/docs/auto-ticket-per-step-subagents-plan.md
@@ -10,7 +10,8 @@
 
 ## Global Constraints
 
-- **Additive & opt-in:** no interactive path and none of the five lifecycle skills' frontmatter/behavior may change. All new behavior gated behind `fork_steps` / `model_<step>` / the autonomous signal.
+- **Additive & opt-in:** no interactive *logic/behavior* of the five lifecycle skills changes. The ONLY frontmatter change permitted is the per-skill `model:` line (see the model strategy below): `work-ticket`/`review-ticket` → `inherit`, `push` → `haiku`; `pr-feedback`/`finish-ticket`/`validate` stay `sonnet`. All other new behavior is gated behind `fork_steps` / `model_<step>` / the autonomous signal.
+- **Model strategy (removes clobber at the source):** skills either `inherit` (no pinned model to fight the step-agent) or already match their step-agent's model, so per-step models are correct by construction. The step-agents remain the authoritative model source; the preload-not-invoke approach is belt-and-suspenders.
 - **Handshake contract unchanged:** steps still end with the `status: clean | fixable-findings | needs-human | done` fenced block (contract §3); it now returns across the subagent boundary. A missing handshake = `needs-human`.
 - **Config precedence:** new keys resolve project `.claude/ccmagic.local.md` → user `~/.claude/ccmagic.local.md` → built-in default (contract §5).
 - **Balanced model mapping (defaults):** work-ticket→`opus`, review-ticket→`opus`, pr-feedback→`sonnet`, finish-ticket→`sonnet`, validate→`sonnet`, push→`haiku`.
@@ -144,6 +145,37 @@ In a repo wired to a tracker (e.g. the MagicMenu repo with the Linear MCP), with
 cd /Users/devon/git/ccmagic
 git add agents/auto-push.md skills/auto-ticket/SKILL.md
 git commit -m "feat(auto-ticket): fork the push step via per-step agent (PoC)"
+```
+
+---
+
+### Task 1.5: Adjust lifecycle-skill model frontmatter
+
+Removes the model-clobber risk at the source (see design "Skill-frontmatter model strategy"). Frontmatter `model:` line only — no logic changes.
+
+**Files:**
+- Modify: `skills/work-ticket/SKILL.md`, `skills/review-ticket/SKILL.md`, `skills/push/SKILL.md`
+
+- [ ] **Step 1:** In `skills/work-ticket/SKILL.md` frontmatter, change `model: sonnet` → `model: inherit`.
+- [ ] **Step 2:** In `skills/review-ticket/SKILL.md` frontmatter, change `model: sonnet` → `model: inherit`.
+- [ ] **Step 3:** In `skills/push/SKILL.md` frontmatter, change `model: sonnet` → `model: haiku`.
+- [ ] **Step 4:** Leave `pr-feedback`, `finish-ticket`, `validate` at `sonnet` (they already match their step-agent — do not touch).
+- [ ] **Step 5: Verify**
+
+```bash
+cd /Users/devon/git/ccmagic
+for s in work-ticket review-ticket push pr-feedback finish-ticket validate; do
+  echo "$s: $(grep -m1 '^model:' skills/$s/SKILL.md)"
+done
+```
+Expected: `work-ticket`/`review-ticket` = `inherit`, `push` = `haiku`, the other three = `sonnet`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/devon/git/ccmagic
+git add skills/work-ticket/SKILL.md skills/review-ticket/SKILL.md skills/push/SKILL.md
+git commit -m "feat(skills): tune lifecycle-skill models (work/review inherit, push haiku)"
 ```
 
 ---

--- a/docs/ccmagic.local.md.example
+++ b/docs/ccmagic.local.md.example
@@ -63,7 +63,7 @@ max_feedback_passes: 3
 
 # --- Per-step execution (used by /ccmagic:auto-ticket) ---
 # Run each lifecycle step in its own forked subagent (default true). Set false
-# to run every step inline in one context (the 3.1.0 behavior).
+# to run every step inline in one context (the orchestrator itself still runs forked).
 fork_steps: true
 # Per-step model (defaults shown = the Balanced mapping; set only to override):
 # model_work_ticket:   opus
@@ -72,6 +72,7 @@ fork_steps: true
 # model_finish_ticket: sonnet
 # model_validate:      sonnet
 # model_push:          haiku
+# The agent frontmatter (agents/auto-<step>.md) is the authoritative model; edit it to change a step's model with certainty.
 ---
 
 # ccmagic project settings

--- a/docs/ccmagic.local.md.example
+++ b/docs/ccmagic.local.md.example
@@ -60,6 +60,18 @@ max_feedback_passes: 3
 # max_validate_attempts: 2
 # ci_timeout_minutes: 30
 # ci_poll_interval_seconds: 60
+
+# --- Per-step execution (used by /ccmagic:auto-ticket) ---
+# Run each lifecycle step in its own forked subagent (default true). Set false
+# to run every step inline in one context (the 3.1.0 behavior).
+fork_steps: true
+# Per-step model (defaults shown = the Balanced mapping; set only to override):
+# model_work_ticket:   opus
+# model_review_ticket: opus
+# model_pr_feedback:   sonnet
+# model_finish_ticket: sonnet
+# model_validate:      sonnet
+# model_push:          haiku
 ---
 
 # ccmagic project settings
@@ -84,6 +96,8 @@ Copy this file to **`.claude/ccmagic.local.md`** in your project root and edit t
 | `max_validate_attempts` | Cap on local `/ccmagic:validate` fix attempts in an autonomous run before parking. | `2` |
 | `ci_timeout_minutes` | Max minutes to wait for CI to settle before parking on timeout. | `30` |
 | `ci_poll_interval_seconds` | Interval between CI status polls in an autonomous run. | `60` |
+| `fork_steps` | Run each `auto-ticket` step in its own forked subagent. | `true` |
+| `model_<step>` | Per-step model override (`model_work_ticket` … `model_push`). | Balanced mapping |
 
 Every key above also has effect from a **user-level** `~/.claude/ccmagic.local.md` — the project file (this one) takes precedence over the user file, and both override the built-in defaults. Put personal defaults you want in every project (e.g. a longer `ci_timeout_minutes`) in the user file; override them per-repo here.
 

--- a/docs/ccmagic.local.md.example
+++ b/docs/ccmagic.local.md.example
@@ -62,9 +62,7 @@ max_feedback_passes: 3
 # ci_poll_interval_seconds: 60
 
 # --- Per-step execution (used by /ccmagic:auto-ticket) ---
-# Run each lifecycle step in its own forked subagent (default true). Set false
-# to run every step inline in one context (the orchestrator itself still runs forked).
-fork_steps: true
+# Each lifecycle step always runs in its own forked subagent.
 # Per-step model (defaults shown = the Balanced mapping; set only to override):
 # model_work_ticket:   opus
 # model_review_ticket: opus
@@ -97,7 +95,6 @@ Copy this file to **`.claude/ccmagic.local.md`** in your project root and edit t
 | `max_validate_attempts` | Cap on local `/ccmagic:validate` fix attempts in an autonomous run before parking. | `2` |
 | `ci_timeout_minutes` | Max minutes to wait for CI to settle before parking on timeout. | `30` |
 | `ci_poll_interval_seconds` | Interval between CI status polls in an autonomous run. | `60` |
-| `fork_steps` | Run each `auto-ticket` step in its own forked subagent. | `true` |
 | `model_<step>` | Per-step model override (`model_work_ticket` … `model_push`). | Balanced mapping |
 
 Every key above also has effect from a **user-level** `~/.claude/ccmagic.local.md` — the project file (this one) takes precedence over the user file, and both override the built-in defaults. Put personal defaults you want in every project (e.g. a longer `ci_timeout_minutes`) in the user file; override them per-repo here.

--- a/docs/cyrus-prompt-relay-transport-design.md
+++ b/docs/cyrus-prompt-relay-transport-design.md
@@ -1,0 +1,124 @@
+# Design: prompt-relay transport for the headless-Linear (Cyrus) path
+
+**Status:** scoped, reviewed, **decisions locked** — not yet scheduled, no branch, no code. Written 2026-07-18; revised same day after design review + in-container verification on the live Cyrus instance (`server.tr0n.io`, container `cyrus`).
+**Trigger:** running `/ccmagic:auto-ticket` (and the lifecycle skills) inside Cyrus, where there is **no Linear MCP** in the container — the ticket flows into the prompt, and the agent's output is relayed back to Linear as activity/comments.
+
+---
+
+## 1. The core reframe: transport, not tracker
+
+ccmagic models one axis today — **which tracker** (Linear / GitHub / JIRA) — and assumes each is reached through a **direct API**: Linear/JIRA via MCP, GitHub via `gh`. Cyrus keeps the tracker (**Linear**) but swaps the **transport**:
+
+| Operation | Normal (today) | Prompt-relay (Cyrus) |
+|---|---|---|
+| Read ticket | `mcp__*Linear*__get_issue` | injected into the invocation (see §4.2 — it does **not** ride along for free) |
+| Branch / worktree | `work-ticket` creates it | Cyrus already created it (worktree per issue, branch from issue id) |
+| Initial state → In Progress | `save_issue` | Cyrus already did it on assignment ("started") |
+| Write a comment | `save_comment` | the agent's output stream **is** the comment — Cyrus relays activity to Linear |
+| State → In Review / Done / needs-human | `save_issue` | **no API** — Cyrus session-lifecycle + Linear's GitHub automation own it |
+| PR link on the ticket | attachment via MCP | Linear's GitHub integration auto-links the PR via the issue-id branch name |
+| File follow-up ticket | create issue via MCP | **no API** — listed in the final summary for a human |
+| PR / git / push / merge / CI | `gh` | **unchanged** — `gh` verified authed in-container (§6) |
+
+**Consequence:** the whole orchestration and the entire GitHub/PR half are unaffected. Only the *Linear side* loses its API — reads come in with the invocation, writes go out as the relayed message. So the fix is a **new transport mode**, branched at ~6 tracker-I/O points, not a new skill (a separate `cyrus-ticket` skill would duplicate orchestration and drift).
+
+**Naming:** the canonical vocabulary is **`prompt-relay`** everywhere — contract section, skill branches, grounding-block field. Cyrus is the motivating deployment and appears only in docs/README as an example. Any future headless harness that pre-injects ticket content (Linear or otherwise) reuses the transport unchanged; nothing product-named lands in the plugin's contract surface.
+
+Refs: [cyrusagents/cyrus](https://github.com/cyrusagents/cyrus), self-hosting write-up ([digitalsanctuary.com](https://www.digitalsanctuary.com/posts/self-hosting-a-linear-driven-claude-code-agent-with-cyrus)).
+
+## 2. Decisions locked
+
+- **Merge policy: full auto-merge.** A Cyrus run drives the entire cycle exactly like laptop `auto-ticket` — merge when CI is green and the work is clean, **park** otherwise. No new merge-gating config; the existing merge/park logic is reused unchanged.
+- **State control: Cyrus + Linear own it.** The agent **never** attempts a Linear state transition. Every `set_state` call becomes a no-op that emits an intent line into the relayed output. Ticket → Done on merge is handled by **Linear's GitHub integration automation** (auto-close on linked-PR merge — confirmed enabled on the team); this is a documented deployment prerequisite, not code. "Couldn't move state" is **never** a failure or a park trigger.
+- **Detection: content-presence, zero config.** No `environment:`/`tracker_transport:` key, no TTY heuristic. Rule: tracker resolves to `linear` **and** no `mcp__*Linear*__*` tool is present **and** ticket content was explicitly passed in the invocation args/grounding → transport = `prompt-relay`. A laptop run never has injected content, so there are no false positives — a laptop with a briefly-missing MCP has no content and stops exactly as today. This also keeps `.claude/ccmagic.local.md` identical across laptop and container (it's per-repo, checked out in both — an environment key there would have forced prompt-relay onto laptop runs).
+- **Writes: relay-only.** No direct Linear API path. Verified in-container (§6): there is **no usable Linear access token in the environment** — only Cyrus's own OAuth client credentials and webhook secret; per-workspace tokens live in Cyrus's internal state. A direct-API path would couple ccmagic to Cyrus internals for marginal gain. The §4.3 operations are op-shaped, so a direct-API implementation could slot in per-op later without restructuring.
+- **Progress: single consolidated final message.** Linear gets one Step 6 summary (or parked note); the PR carries the detailed near-real-time audit trail via `gh`. Live per-step progress lines in Linear are deferred (would require verifying/re-plumbing how forked-skill intermediate output is relayed).
+- **Shape: extend, don't fork.** Add a prompt-relay transport branch to the existing skills + one shared contract section. No new orchestrator.
+
+## 3. What breaks in the current code
+
+1. **Detection cascade** (`skills/work-ticket/SKILL.md:36-37`) — the MCP probe looks for `mcp__*Linear*__get_issue`; that tool doesn't exist in-container, so the cascade never resolves `linear` and falls through to "none available → stop." Dead on arrival.
+2. **Ticket content doesn't cross the fork boundaries.** Cyrus injects the issue into the *top-level* prompt, but `auto-ticket` is `context: fork` (it sees only SKILL.md + its arguments) and then forks every step again — and the grounding block (`autonomous-contract.md` §2) carries tracker/ticket-ID/URL but **no ticket content**. "Already in the prompt" is false two hops deep. Content must be plumbed explicitly (§4.2).
+3. **Every `mcp__*Linear*__*` call fails** — fetches (`work-ticket:55`, `review-ticket`, `finish-ticket:89`, `auto-ticket` Step 0.4), state writes (`work-ticket:95,252`; `finish-ticket:312-313`), attachments, and the follow-up-issue creation in `pr-feedback`.
+4. **Park routine** (`autonomous-contract.md` §4) leads with "move the ticket to `needs_human_state` via `save_issue`" — no API to do it.
+5. **Multi-comment + subagent relay** — the flow posts several discrete comments, but Cyrus relays the *stream*, and post-v3.2.0 only the top-level session's stream reaches Linear (per-step subagent output stays internal). "Post a ticket comment" must collapse to one consolidated top-level message (§4.3, §4.5).
+6. **Stale note** — `auto-ticket/SKILL.md:222` claims the cycle is "safe to launch from Cyrus." It silently assumes the Linear MCP works in-container; it doesn't. Fix the note.
+
+## 4. Design
+
+### 4.1 Detect the transport
+Add transport resolution to `work-ticket` Step 0b and `auto-ticket` Step 0, *before* the "none available → stop" branch:
+
+> Tracker resolved to `linear` (via config or arg shape) **and** no `mcp__*Linear*__*` tool present **and** ticket content explicitly provided in the invocation args / grounding block → transport = `prompt-relay`. Otherwise the cascade behaves exactly as today.
+
+No new config keys. (Noted for completeness: the container environment does expose `CYRUS_*` variables that could serve as a detection signal, but content-presence is sufficient, harness-agnostic, and self-authorizing — rejected as an unnecessary second path.)
+
+### 4.2 Content plumbing (the load-bearing addition)
+The ticket content must travel through both fork boundaries explicitly:
+
+- **Cyrus prompt template contract (documented, not code):** the repo's Cyrus prompt must invoke `/ccmagic:auto-ticket {TICKET-ID}` **with the issue title + description included in the message**, so the main-loop model passes it into the forked skill's arguments. This is the only channel that survives `context: fork`.
+- **Grounding block extension** (`autonomous-contract.md` §2): add a `transport: mcp | prompt-relay` field, and — under prompt-relay only — a fenced `ticket_content:` section (title + description) so every per-step agent receives the content. Fence with a delimiter that tolerates backticks in issue bodies (e.g. `~~~` or a labeled heredoc-style marker).
+- **`fetch_ticket` semantics:** read from args/grounding. If transport is prompt-relay and content is absent → **setup error, stop and say so** (not a guess, not a park — the caller should have injected it). This *strengthens* the Sacred Rule: content is explicitly provided, never inferred.
+
+### 4.3 One shared operations section (DRY)
+Add `## 7. Prompt-relay transport` to `autonomous-contract.md` defining the operations below; each tracker-I/O step in the skills gets a one-line "in prompt-relay transport, see contract §7" pointer instead of a duplicated branch.
+
+| Op | Prompt-relay behavior |
+|---|---|
+| `fetch_ticket(id)` | From args/grounding per §4.2. Absent → setup error, stop. |
+| `set_state(In Progress)` | No-op — Cyrus already moved to "started". |
+| `set_state(In Review \| Done \| needs_human)` | No-op at the API level; emit an intent line ("Requested state: Done") in the final message. Cyrus lifecycle / Linear automation owns the move. Never a failure. |
+| `comment(ticket, body)` | **Skip.** No accumulation machinery — the PR carries the detailed audit trail via `gh`, and the orchestrator's Step 6 summary is the single Linear-facing message. |
+| `link_pr(url)` | Include the PR URL in the final summary. Linear's GitHub integration auto-links via the issue-id branch name anyway. No attachment API. |
+| `file_followup(desc)` | No create API — collect follow-ups and list them under "Follow-ups to file" in the final summary for a human. |
+
+### 4.4 Park under prompt-relay (`autonomous-contract.md` §4 extension)
+1. Do not merge (unchanged).
+2. **Skip** the Linear state move (no API); rely on Cyrus/human. Because park means "not done" and nothing will infer "Blocked," the relayed parked note must be unmistakable.
+3. Post the parked template to the **PR** via `gh pr comment` (GitHub side intact) **and** emit it as the top-level Linear-facing message.
+4. Exit cleanly.
+5. *(Future)* If Cyrus exposes an agent→Linear "awaiting input" / approval element, use it so park surfaces natively.
+
+### 4.5 Subagent / relay handling
+- Only the top-level session stream reaches Linear; per-step subagent output stays internal. The **Step 6 run summary (or parked note) must be emitted as the orchestrator's own final top-level output** so it survives the return to the main loop.
+- **Verbatim mitigations** (the one link the plugin can't control is the main-loop model paraphrasing the forked skill's return):
+  1. The orchestrator ends its returned text with a clearly delimited "FINAL MESSAGE TO RELAY — reproduce verbatim" block.
+  2. The documented Cyrus prompt template instructs the session to repeat the skill's returned summary verbatim as its final message.
+- Whether Cyrus relays the forked skill's returned text faithfully is the **remaining unknown** (§6 R1) — it's the primary live-test item.
+
+## 5. Files to touch (when built)
+
+- `skills/auto-ticket/autonomous-contract.md` — §2 grounding-block schema (`transport:`, fenced `ticket_content:`); §4 park fallback; new §7 (prompt-relay ops). **No new config keys.**
+- `skills/auto-ticket/SKILL.md` — Step 0 transport resolution (content-presence rule); Step 6 summary as delimited top-level final output under prompt-relay; fix the stale note at :222.
+- `skills/work-ticket/SKILL.md` — Step 0b detection; Step 1 fetch-from-grounding; Step 2 skip assign/In-Progress; In-Review write → intent line.
+- `skills/review-ticket/SKILL.md` — fetch-from-grounding branch.
+- `skills/finish-ticket/SKILL.md` — fetch-from-grounding; state transitions → no-op/intent; closing ticket comment → skip (summary covers it); **merge still via `gh`**.
+- `skills/pr-feedback/SKILL.md` — follow-up creation → collect & list in output.
+- `skills/doctor/SKILL.md` — recognize the prompt-relay transport so it doesn't report "no tracker."
+- `README.md` + a short Cyrus deployment doc — prompt template (invoke with issue content; verbatim-repeat instruction) and prerequisites (Linear GitHub auto-close automation enabled; `gh` authed in-container). `docs/ccmagic.local.md.example` needs no change (no new keys).
+- Version bump (minor) + `CHANGELOG.md` entry at build time.
+
+## 6. Questions — resolved & remaining
+
+**Resolved (design review + in-container verification, 2026-07-18):**
+
+1. ~~Does the ticket reach Done after auto-merge?~~ **Yes** — Linear's GitHub integration auto-close automation is enabled on the team; it moves the issue on linked-PR merge. Documented as a deployment prerequisite; the summary still carries a "merged — requested state: Done" intent line as belt-and-braces. Confirm end-to-end in the live test.
+2. ~~What signal identifies "inside Cyrus"?~~ **Moot** — detection is content-presence (§2, §4.1); no environment signal needed.
+3. ~~Is `gh` authed in-container?~~ **Yes, verified** — `gh` present at `/usr/bin/gh`, logged in via `GH_TOKEN`. Also verified: **no per-user Linear access token in the container env** (only Cyrus's OAuth client id/secret + webhook secret), which confirms relay-only as the right write path.
+4. ~~Single final summary vs live progress?~~ **Final summary only** (locked, §2).
+
+**Remaining:**
+
+- **R1 (live-test gate):** does Cyrus relay the forked skill's returned summary to Linear faithfully (not paraphrased/truncated)? Mitigations in §4.5; this is what the throwaway-ticket test primarily verifies.
+- **R2 (future):** does Cyrus expose an agent→Linear structured signal (awaiting-input / issue-creation) the park + follow-up paths could use natively? Not needed for v1.
+
+## 7. Testing
+
+1. **Structural** — greps + local plugin load-test, as usual.
+2. **Laptop headless simulation** (no Cyrus needed): `claude -p` with the Linear MCP unconfigured and a crafted prompt embedding a fake ticket + the auto-ticket invocation. Exercises detection, fetch-from-args, the no-op state ops, comment-skip, and final-message emission — most of the design.
+3. **Live gate** — a throwaway Linear ticket on the real Cyrus instance, confirming: transport detected → ticket read from grounding → PR flow → merge on clean / park on needs-human → the relayed final message lands as a Linear comment **verbatim** (R1) → the ticket reaches Done via the Linear automation.
+
+## 8. Effort / risk
+
+- **Effort:** moderate — one shared contract section + grounding-block extension + ~6 skill I/O branches + detection + docs. No new orchestration; reuses the existing merge/park logic.
+- **Risk:** low to interactive/MCP paths (purely additive branch, gated on the transport rule — content-presence can't trigger on a laptop). The main residual risk is R1 (relay fidelity of the final summary), mitigated by the delimited-block + prompt-template instructions and gated by the live test. The former top risk (merged ticket stuck In Progress) is retired by the confirmed Linear auto-close automation.

--- a/skills/auto-ticket/SKILL.md
+++ b/skills/auto-ticket/SKILL.md
@@ -37,7 +37,7 @@ This skill and every sub-skill it calls share one contract — the autonomous si
 - **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
 - **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (the 3.1.0 behavior, one level down).
 
-Call this `run_step(step, grounding)`. In this iteration only the **push** step routes through `run_step`: run the `/ccmagic:push` commit-and-push call sites (in the Step 3 review-fix loop and Step 4b validate-fix) via `run_step` — forked to the `auto-push` agent when `fork_steps` is true, inline via `Skill` otherwise. All other steps continue to run inline as in 3.1.0; a later change routes them too. Nothing else about the flow (route-and-stop, loops, bounds) changes.
+Call this `run_step(step, grounding)`. **Every step below runs through `run_step`** — forked to its per-step agent (see the registry) when `fork_steps` is true, inline via `Skill` otherwise, including the `/ccmagic:push` commit-and-push call sites in the Step 3 review-fix loop and Step 4b validate-fix. Nothing else about the flow (route-and-stop, loops, bounds) changes.
 
 ### Per-step agent registry
 
@@ -50,7 +50,7 @@ Call this `run_step(step, grounding)`. In this iteration only the **push** step 
 | finish-ticket | `auto-finish` | `sonnet` | `model_finish_ticket` |
 | push | `auto-push` | `haiku` | `model_push` |
 
-Model resolution per step: the agent's frontmatter `model:` is the authoritative default; if a `model_<step>` config value is set, pass it as the `Task` per-invocation model override (best-effort). Only `push` is wired in this iteration; the rest are added in a later change.
+Model resolution per step: the agent's frontmatter `model:` is the authoritative default; if a `model_<step>` config value is set, pass it as the `Task` per-invocation model override (best-effort). All six steps route through `run_step`. When `fork_steps` is false, every step falls back to an inline `Skill` invocation in this orchestrator's context.
 
 ---
 
@@ -58,7 +58,7 @@ Model resolution per step: the agent's frontmatter `model:` is the authoritative
 
 1. **Resolve the tracker** using the exact same cascade as `/ccmagic:work-ticket` Step 0 (settings → arg/branch shape → MCP probe → CLI probe → branch hint). This runs unattended, so if the cascade is genuinely ambiguous (would otherwise prompt), pick the highest-confidence candidate and record the choice in the run summary; if **none** is available, stop and tell the user (this is a setup error, not a parkable ticket).
 2. **Resolve the ticket ID** from the argument, or parse it from the current branch (strip `feature/`, `bugfix/`, `hotfix/`, `chore/` prefixes) — same logic as `/ccmagic:finish-ticket` Step 1. If neither yields a ticket ID, **exit cleanly** with a one-line message asking the caller to pass one (`/ccmagic:auto-ticket {TICKET-ID}`) — this is a setup error, not a parkable ticket; do not wait for input.
-3. **Load config**, resolving each value by precedence — an explicit arg → the project file `.claude/ccmagic.local.md` → the user file `~/.claude/ccmagic.local.md` → the built-in default (see contract §5). Keys: `needs_human_state`, `needs_human_label` (default `needs-human`), `max_feedback_passes` (default `3`), `max_review_fix_passes` (default `2`), `max_validate_attempts` (default `2`), `ci_timeout_minutes` (default `30`), `ci_poll_interval_seconds` (default `60`), plus the usual `tracker` / `ticket_url_base` / `github_repo`.
+3. **Load config**, resolving each value by precedence — an explicit arg → the project file `.claude/ccmagic.local.md` → the user file `~/.claude/ccmagic.local.md` → the built-in default (see contract §5). Keys: `needs_human_state`, `needs_human_label` (default `needs-human`), `max_feedback_passes` (default `3`), `max_review_fix_passes` (default `2`), `max_validate_attempts` (default `2`), `ci_timeout_minutes` (default `30`), `ci_poll_interval_seconds` (default `60`), plus the usual `tracker` / `ticket_url_base` / `github_repo`, `fork_steps` (bool, default `true`), and the per-step model overrides `model_work_ticket`, `model_review_ticket`, `model_pr_feedback`, `model_finish_ticket`, `model_validate`, `model_push` (each defaulting to the registry value).
 4. **Fetch the ticket** to confirm it exists (per the tracker's lookup in `work-ticket`/`review-ticket`). If not found, stop (Sacred Rule).
 5. **Build the grounding block** (contract §2) with the resolved values. Prepend it to every sub-skill invocation below. `/ccmagic:auto-ticket` always drives sub-skills with `autonomous: true`, regardless of the `autonomous:` config default.
 
@@ -68,7 +68,9 @@ Create a TodoWrite entry per stage (work → review → feedback loop → finish
 
 ## Step 1: Work the ticket
 
-Invoke `/ccmagic:work-ticket {TICKET-ID}` with the grounding block prepended.
+> Each step below is executed via `run_step` (see *Step execution mode*): forked to its per-step agent when `fork_steps` is true, inline otherwise. The grounding block and handshake parsing are identical either way.
+
+Run the work-ticket step via `run_step` — `/ccmagic:work-ticket {TICKET-ID}` with the grounding block prepended.
 
 - It classifies, branches, implements, self-reviews, validates scope, and opens the PR — all without pausing (see its *Autonomous mode*).
 - **Parse the handshake:**
@@ -91,7 +93,7 @@ Store `{PR_NUMBER}`, `{PR_URL}`, `{BASE_BRANCH}`. Add `pr:` to the grounding blo
 
 ## Step 3: Ticket-grounded review
 
-Invoke `/ccmagic:review-ticket {TICKET-ID}` with the grounding block prepended. Then act on the verdict:
+Run the review-ticket step via `run_step` — `/ccmagic:review-ticket {TICKET-ID}` with the grounding block prepended. Then act on the verdict:
 
 - `clean` → continue to Step 4.
 - `needs-human` → **route-and-stop** (stage = `review-ticket`).
@@ -115,10 +117,10 @@ gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/comments --jq '[.[].id] | max // 0
 
 Everything this pass pushes is measured against `H`, so bot reviews triggered *by* this pass's push are counted as new (4c). Then:
 
-**4a. Apply feedback.** Invoke `/ccmagic:pr-feedback {PR_NUMBER}` with the grounding block. Autonomous `pr-feedback` applies address-now fixes, replies to declined/question threads, files a follow-up ticket per defer/out-of-scope item, and pushes. Collect its handshake counts and `follow_ups`.
+**4a. Apply feedback.** Run the pr-feedback step via `run_step` — `/ccmagic:pr-feedback {PR_NUMBER}` with the grounding block. Autonomous `pr-feedback` applies address-now fixes, replies to declined/question threads, files a follow-up ticket per defer/out-of-scope item, and pushes. Collect its handshake counts and `follow_ups`.
   - `needs-human` (e.g. a genuine reviewer tie) → **route-and-stop** (stage = `pr-feedback`).
 
-**4b. Validate locally before trusting CI.** Run `/ccmagic:validate`. If it fails, fix the regressions (bounded: `max_validate_attempts` attempts, default **2**, editing + re-validating), then commit/push via `/ccmagic:push` (run this via `run_step`). If it still fails after the attempts → **route-and-stop** (reason: "local validation fails: {summary}"). Doing this locally keeps CI + bot-review round-trips rare.
+**4b. Validate locally before trusting CI.** Run the validate step via `run_step` — `/ccmagic:validate`. If it fails, fix the regressions (bounded: `max_validate_attempts` attempts, default **2**, editing + re-validating), then commit/push via `/ccmagic:push` (run this via `run_step`). If it still fails after the attempts → **route-and-stop** (reason: "local validation fails: {summary}"). Doing this locally keeps CI + bot-review round-trips rare.
 
 **4c. Wait for CI and new reviews.** This pass's push(es) already happened (in 4a via `pr-feedback`, and possibly again in 4b); `H` was captured before them at the top of the pass. Now that they've landed:
   - Poll CI until it settles — no check is `pending`/`in_progress`:
@@ -141,7 +143,7 @@ Everything this pass pushes is measured against `H`, so bot reviews triggered *b
 
 ## Step 5: Finish the ticket
 
-Invoke `/ccmagic:finish-ticket` with the grounding block. Its Step 3 sanity check is the **merge gate**: it merges only if the PR is mergeable, CI is green, and there are no unaddressed change-requests.
+Run the finish-ticket step via `run_step` — `/ccmagic:finish-ticket` with the grounding block. Its Step 3 sanity check is the **merge gate**: it merges only if the PR is mergeable, CI is green, and there are no unaddressed change-requests.
 
 - `done` → the PR merged and the ticket moved to Done. Continue to Step 6 with outcome **merged**.
 - `needs-human` → the gate wasn't satisfied. It did **not** merge → **route-and-stop** (stage = `finish-ticket`, reason: its blockers).

--- a/skills/auto-ticket/SKILL.md
+++ b/skills/auto-ticket/SKILL.md
@@ -5,6 +5,7 @@ user-invocable: true
 allowed-tools: Read(*), Edit(*), Bash(git:*, gh:*), Glob(*), Grep(*), Task(*), TodoWrite(*), Skill(*)
 argument-hint: "[TICKET-ID] (detects from the current branch if omitted)"
 model: sonnet
+context: fork
 ---
 
 # /auto-ticket — Autonomous Ticket Driver
@@ -26,6 +27,30 @@ This skill and every sub-skill it calls share one contract — the autonomous si
 - Sub-skills are invoked in autonomous mode by prepending the **grounding block** (contract §2) to their arguments. Because the block carries `orchestrator: auto-ticket`, sub-skills return their handshake and let **this** skill park — they never park themselves.
 - Every sub-skill ends with a **handshake** (contract §3): `status: clean | fixable-findings | needs-human | done`. Parse the last one. A missing handshake = treat as `needs-human`.
 - **`route-and-stop`** (contract §4) is the one way this skill ends a run early. Every exit path is either **merged** or **parked-needs-human** — never stalled.
+
+---
+
+## Step execution mode
+
+`auto-ticket` runs **forked** (`context: fork`), so it executes as a subagent and can spawn a child subagent per step. How each step below runs is decided by `fork_steps` (config, default `true`):
+
+- **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
+- **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (the 3.1.0 behavior, one level down).
+
+Call this `run_step(step, grounding)`. **Every "Invoke `/ccmagic:<skill>`" instruction in the steps below goes through `run_step`** — nothing else about the flow (route-and-stop, loops, bounds) changes.
+
+### Per-step agent registry
+
+| Step | Agent | Default model | Config override |
+|------|-------|---------------|-----------------|
+| work-ticket | `auto-work` | `opus` | `model_work_ticket` |
+| review-ticket | `auto-review` | `opus` | `model_review_ticket` |
+| pr-feedback | `auto-feedback` | `sonnet` | `model_pr_feedback` |
+| validate | `auto-validate` | `sonnet` | `model_validate` |
+| finish-ticket | `auto-finish` | `sonnet` | `model_finish_ticket` |
+| push | `auto-push` | `haiku` | `model_push` |
+
+Model resolution per step: the agent's frontmatter `model:` is the authoritative default; if a `model_<step>` config value is set, pass it as the `Task` per-invocation model override (best-effort). Only `push` is wired in this iteration; the rest are added in a later change.
 
 ---
 

--- a/skills/auto-ticket/SKILL.md
+++ b/skills/auto-ticket/SKILL.md
@@ -35,7 +35,7 @@ This skill and every sub-skill it calls share one contract — the autonomous si
 `auto-ticket` runs **forked** (`context: fork`), so it executes as a subagent and can spawn a child subagent per step. How each step below runs is decided by `fork_steps` (config, default `true`):
 
 - **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
-- **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (the 3.1.0 behavior, one level down).
+- **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (run steps inline in the orchestrator's own context — `auto-ticket` itself still runs forked, so this is not identical to the pre-3.2.0 flow).
 
 Call this `run_step(step, grounding)`. **Every step below runs through `run_step`** — forked to its per-step agent (see the registry) when `fork_steps` is true, inline via `Skill` otherwise, including the `/ccmagic:push` commit-and-push call sites in the Step 3 review-fix loop and Step 4b validate-fix. Nothing else about the flow (route-and-stop, loops, bounds) changes.
 
@@ -100,7 +100,7 @@ Run the review-ticket step via `run_step` — `/ccmagic:review-ticket {TICKET-ID
 - `fixable-findings` → run a **bounded fix loop** (max `max_review_fix_passes` passes, default **2**):
   1. Apply the CRITICAL findings (and any listed fixable missing-AC items) from the report — edit the code directly.
   2. Commit and push via `/ccmagic:push` with the grounding block (run this via `run_step`). If push returns `needs-human`, **route-and-stop**.
-  3. Re-invoke `/ccmagic:review-ticket`.
+  3. Re-invoke the review-ticket step via `run_step`.
   4. `clean` → continue to Step 4. `fixable-findings` again and passes remain → repeat. Passes exhausted still not clean, or `needs-human` → **route-and-stop** (reason: the outstanding findings).
 
 Only CRITICAL findings and closable missing-AC items gate here. Out-of-scope changes are flagged in the PR (review-ticket already posts them) and do not block.

--- a/skills/auto-ticket/SKILL.md
+++ b/skills/auto-ticket/SKILL.md
@@ -37,7 +37,7 @@ This skill and every sub-skill it calls share one contract — the autonomous si
 - **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
 - **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (the 3.1.0 behavior, one level down).
 
-Call this `run_step(step, grounding)`. **Every "Invoke `/ccmagic:<skill>`" instruction in the steps below goes through `run_step`** — nothing else about the flow (route-and-stop, loops, bounds) changes.
+Call this `run_step(step, grounding)`. In this iteration only the **push** step routes through `run_step`: run the `/ccmagic:push` commit-and-push call sites (in the Step 3 review-fix loop and Step 4b validate-fix) via `run_step` — forked to the `auto-push` agent when `fork_steps` is true, inline via `Skill` otherwise. All other steps continue to run inline as in 3.1.0; a later change routes them too. Nothing else about the flow (route-and-stop, loops, bounds) changes.
 
 ### Per-step agent registry
 
@@ -97,7 +97,7 @@ Invoke `/ccmagic:review-ticket {TICKET-ID}` with the grounding block prepended. 
 - `needs-human` → **route-and-stop** (stage = `review-ticket`).
 - `fixable-findings` → run a **bounded fix loop** (max `max_review_fix_passes` passes, default **2**):
   1. Apply the CRITICAL findings (and any listed fixable missing-AC items) from the report — edit the code directly.
-  2. Commit and push via `/ccmagic:push` with the grounding block. If push returns `needs-human`, **route-and-stop**.
+  2. Commit and push via `/ccmagic:push` with the grounding block (run this via `run_step`). If push returns `needs-human`, **route-and-stop**.
   3. Re-invoke `/ccmagic:review-ticket`.
   4. `clean` → continue to Step 4. `fixable-findings` again and passes remain → repeat. Passes exhausted still not clean, or `needs-human` → **route-and-stop** (reason: the outstanding findings).
 
@@ -118,7 +118,7 @@ Everything this pass pushes is measured against `H`, so bot reviews triggered *b
 **4a. Apply feedback.** Invoke `/ccmagic:pr-feedback {PR_NUMBER}` with the grounding block. Autonomous `pr-feedback` applies address-now fixes, replies to declined/question threads, files a follow-up ticket per defer/out-of-scope item, and pushes. Collect its handshake counts and `follow_ups`.
   - `needs-human` (e.g. a genuine reviewer tie) → **route-and-stop** (stage = `pr-feedback`).
 
-**4b. Validate locally before trusting CI.** Run `/ccmagic:validate`. If it fails, fix the regressions (bounded: `max_validate_attempts` attempts, default **2**, editing + re-validating), then commit/push via `/ccmagic:push`. If it still fails after the attempts → **route-and-stop** (reason: "local validation fails: {summary}"). Doing this locally keeps CI + bot-review round-trips rare.
+**4b. Validate locally before trusting CI.** Run `/ccmagic:validate`. If it fails, fix the regressions (bounded: `max_validate_attempts` attempts, default **2**, editing + re-validating), then commit/push via `/ccmagic:push` (run this via `run_step`). If it still fails after the attempts → **route-and-stop** (reason: "local validation fails: {summary}"). Doing this locally keeps CI + bot-review round-trips rare.
 
 **4c. Wait for CI and new reviews.** This pass's push(es) already happened (in 4a via `pr-feedback`, and possibly again in 4b); `H` was captured before them at the top of the pass. Now that they've landed:
   - Poll CI until it settles — no check is `pending`/`in_progress`:

--- a/skills/auto-ticket/SKILL.md
+++ b/skills/auto-ticket/SKILL.md
@@ -32,12 +32,11 @@ This skill and every sub-skill it calls share one contract — the autonomous si
 
 ## Step execution mode
 
-`auto-ticket` runs **forked** (`context: fork`), so it executes as a subagent and can spawn a child subagent per step. How each step below runs is decided by `fork_steps` (config, default `true`):
+`auto-ticket` runs **forked** (`context: fork`), so it executes as a subagent and can spawn a child subagent per step. Every step below always runs **forked** to its per-step agent: `run_step(step, grounding)` = spawn the step's per-step agent via the `Task` tool, passing the grounding block as the task prompt, on the step's model (see the registry), and parse the **last** handshake block from the child's returned text.
 
-- **`fork_steps: true` (default)** — run the step by spawning its per-step agent via the `Task` tool, passing the grounding block as the task prompt, and parsing the **last** handshake block from the child's returned text. Each per-step agent runs on its own model (see the registry) and in an isolated context.
-- **`fork_steps: false`** — run the step inline via the `Skill` tool inside this orchestrator's own context (run steps inline in the orchestrator's own context — `auto-ticket` itself still runs forked, so this is not identical to the pre-3.2.0 flow).
+There is no inline mode — a forked orchestrator cannot invoke the `context: fork` skills that `work-ticket`/`review-ticket`/`validate` reach, so running steps inline in this orchestrator's own context was never actually achievable. Per-step isolation and per-step models are the whole point of this skill.
 
-Call this `run_step(step, grounding)`. **Every step below runs through `run_step`** — forked to its per-step agent (see the registry) when `fork_steps` is true, inline via `Skill` otherwise, including the `/ccmagic:push` commit-and-push call sites in the Step 3 review-fix loop and Step 4b validate-fix. Nothing else about the flow (route-and-stop, loops, bounds) changes.
+**Every step below runs through `run_step`**, including the `/ccmagic:push` commit-and-push call sites in the Step 3 review-fix loop and Step 4b validate-fix. Nothing else about the flow (route-and-stop, loops, bounds) changes.
 
 ### Per-step agent registry
 
@@ -50,7 +49,7 @@ Call this `run_step(step, grounding)`. **Every step below runs through `run_step
 | finish-ticket | `auto-finish` | `sonnet` | `model_finish_ticket` |
 | push | `auto-push` | `haiku` | `model_push` |
 
-Model resolution per step: the agent's frontmatter `model:` is the authoritative default; if a `model_<step>` config value is set, pass it as the `Task` per-invocation model override (best-effort). All six steps route through `run_step`. When `fork_steps` is false, every step falls back to an inline `Skill` invocation in this orchestrator's context.
+Model resolution per step: the agent's frontmatter `model:` is the authoritative default; if a `model_<step>` config value is set, pass it as the `Task` per-invocation model override (best-effort). All six steps route through `run_step`, always forked.
 
 ---
 
@@ -58,7 +57,7 @@ Model resolution per step: the agent's frontmatter `model:` is the authoritative
 
 1. **Resolve the tracker** using the exact same cascade as `/ccmagic:work-ticket` Step 0 (settings → arg/branch shape → MCP probe → CLI probe → branch hint). This runs unattended, so if the cascade is genuinely ambiguous (would otherwise prompt), pick the highest-confidence candidate and record the choice in the run summary; if **none** is available, stop and tell the user (this is a setup error, not a parkable ticket).
 2. **Resolve the ticket ID** from the argument, or parse it from the current branch (strip `feature/`, `bugfix/`, `hotfix/`, `chore/` prefixes) — same logic as `/ccmagic:finish-ticket` Step 1. If neither yields a ticket ID, **exit cleanly** with a one-line message asking the caller to pass one (`/ccmagic:auto-ticket {TICKET-ID}`) — this is a setup error, not a parkable ticket; do not wait for input.
-3. **Load config**, resolving each value by precedence — an explicit arg → the project file `.claude/ccmagic.local.md` → the user file `~/.claude/ccmagic.local.md` → the built-in default (see contract §5). Keys: `needs_human_state`, `needs_human_label` (default `needs-human`), `max_feedback_passes` (default `3`), `max_review_fix_passes` (default `2`), `max_validate_attempts` (default `2`), `ci_timeout_minutes` (default `30`), `ci_poll_interval_seconds` (default `60`), plus the usual `tracker` / `ticket_url_base` / `github_repo`, `fork_steps` (bool, default `true`), and the per-step model overrides `model_work_ticket`, `model_review_ticket`, `model_pr_feedback`, `model_finish_ticket`, `model_validate`, `model_push` (each defaulting to the registry value).
+3. **Load config**, resolving each value by precedence — an explicit arg → the project file `.claude/ccmagic.local.md` → the user file `~/.claude/ccmagic.local.md` → the built-in default (see contract §5). Keys: `needs_human_state`, `needs_human_label` (default `needs-human`), `max_feedback_passes` (default `3`), `max_review_fix_passes` (default `2`), `max_validate_attempts` (default `2`), `ci_timeout_minutes` (default `30`), `ci_poll_interval_seconds` (default `60`), plus the usual `tracker` / `ticket_url_base` / `github_repo`, and the per-step model overrides `model_work_ticket`, `model_review_ticket`, `model_pr_feedback`, `model_finish_ticket`, `model_validate`, `model_push` (each defaulting to the registry value).
 4. **Fetch the ticket** to confirm it exists (per the tracker's lookup in `work-ticket`/`review-ticket`). If not found, stop (Sacred Rule).
 5. **Build the grounding block** (contract §2) with the resolved values. Prepend it to every sub-skill invocation below. `/ccmagic:auto-ticket` always drives sub-skills with `autonomous: true`, regardless of the `autonomous:` config default.
 
@@ -68,7 +67,7 @@ Create a TodoWrite entry per stage (work → review → feedback loop → finish
 
 ## Step 1: Work the ticket
 
-> Each step below is executed via `run_step` (see *Step execution mode*): forked to its per-step agent when `fork_steps` is true, inline otherwise. The grounding block and handshake parsing are identical either way.
+> Each step below is executed via `run_step` (see *Step execution mode*): always forked to its per-step agent.
 
 Run the work-ticket step via `run_step` — `/ccmagic:work-ticket {TICKET-ID}` with the grounding block prepended.
 

--- a/skills/auto-ticket/autonomous-contract.md
+++ b/skills/auto-ticket/autonomous-contract.md
@@ -35,7 +35,7 @@ max_feedback_passes: {n}
 
 A sub-skill that sees `orchestrator:` in its grounding block must **not** park on `needs-human` — it emits the handshake and returns control so the orchestrator performs the single route-and-stop.
 
-When `fork_steps` is true, `auto-ticket` runs each step in a per-step subagent (`agents/auto-*.md`) on the step's model, passing this grounding block as the child's task prompt and reading back the child's handshake (§3). The child agents preload their lifecycle skill rather than invoking it, so the step runs on the agent's model. With `fork_steps: false`, steps run inline via the `Skill` tool. Either way the grounding block and handshake are identical.
+`auto-ticket` always runs each step in a per-step subagent (`agents/auto-*.md`) on the step's model, passing this grounding block as the child's task prompt and reading back the child's handshake (§3). The child agents preload their lifecycle skill rather than invoking it, so the step runs on the agent's model. The grounding block and handshake are unchanged by this — they're identical to how a directly-invoked sub-skill reads and emits them.
 
 ## 3. The status handshake
 
@@ -105,7 +105,6 @@ Nothing was merged. Resolve the item above, then re-run `/ccmagic:auto-ticket {T
 | `max_validate_attempts` | int | `2` | Cap on local `/ccmagic:validate` fix attempts (orchestrator Step 4b) before parking. |
 | `ci_timeout_minutes` | int | `30` | Max minutes to wait for CI to settle (orchestrator Step 4c) before parking on timeout. |
 | `ci_poll_interval_seconds` | int | `60` | Interval between CI status polls (orchestrator Step 4c). |
-| `fork_steps` | bool | `true` | Run each lifecycle step in its own forked subagent; `false` runs steps inline in the orchestrator's own context (which itself still runs forked). |
 | `model_work_ticket` | string | `opus` | Model for the work step's agent (`auto-work`). |
 | `model_review_ticket` | string | `opus` | Model for the review step's agent (`auto-review`). |
 | `model_pr_feedback` | string | `sonnet` | Model for the pr-feedback step's agent (`auto-feedback`). |

--- a/skills/auto-ticket/autonomous-contract.md
+++ b/skills/auto-ticket/autonomous-contract.md
@@ -35,6 +35,8 @@ max_feedback_passes: {n}
 
 A sub-skill that sees `orchestrator:` in its grounding block must **not** park on `needs-human` — it emits the handshake and returns control so the orchestrator performs the single route-and-stop.
 
+When `fork_steps` is true, `auto-ticket` runs each step in a per-step subagent (`agents/auto-*.md`) on the step's model, passing this grounding block as the child's task prompt and reading back the child's handshake (§3). The child agents preload their lifecycle skill rather than invoking it, so the step runs on the agent's model. With `fork_steps: false`, steps run inline via the `Skill` tool. Either way the grounding block and handshake are identical.
+
 ## 3. The status handshake
 
 In autonomous mode, every sub-skill ends its output with a fenced block:
@@ -102,6 +104,13 @@ Nothing was merged. Resolve the item above, then re-run `/ccmagic:auto-ticket {T
 | `max_validate_attempts` | int | `2` | Cap on local `/ccmagic:validate` fix attempts (orchestrator Step 4b) before parking. |
 | `ci_timeout_minutes` | int | `30` | Max minutes to wait for CI to settle (orchestrator Step 4c) before parking on timeout. |
 | `ci_poll_interval_seconds` | int | `60` | Interval between CI status polls (orchestrator Step 4c). |
+| `fork_steps` | bool | `true` | Run each lifecycle step in its own forked subagent; `false` runs them inline in the orchestrator. |
+| `model_work_ticket` | string | `opus` | Model for the work step's agent (`auto-work`). |
+| `model_review_ticket` | string | `opus` | Model for the review step's agent (`auto-review`). |
+| `model_pr_feedback` | string | `sonnet` | Model for the pr-feedback step's agent (`auto-feedback`). |
+| `model_finish_ticket` | string | `sonnet` | Model for the finish step's agent (`auto-finish`). |
+| `model_validate` | string | `sonnet` | Model for the validate step's agent (`auto-validate`). |
+| `model_push` | string | `haiku` | Model for the push step's agent (`auto-push`). |
 
 **Where keys are read — precedence (highest first):**
 

--- a/skills/auto-ticket/autonomous-contract.md
+++ b/skills/auto-ticket/autonomous-contract.md
@@ -105,7 +105,7 @@ Nothing was merged. Resolve the item above, then re-run `/ccmagic:auto-ticket {T
 | `max_validate_attempts` | int | `2` | Cap on local `/ccmagic:validate` fix attempts (orchestrator Step 4b) before parking. |
 | `ci_timeout_minutes` | int | `30` | Max minutes to wait for CI to settle (orchestrator Step 4c) before parking on timeout. |
 | `ci_poll_interval_seconds` | int | `60` | Interval between CI status polls (orchestrator Step 4c). |
-| `fork_steps` | bool | `true` | Run each lifecycle step in its own forked subagent; `false` runs them inline in the orchestrator. |
+| `fork_steps` | bool | `true` | Run each lifecycle step in its own forked subagent; `false` runs steps inline in the orchestrator's own context (which itself still runs forked). |
 | `model_work_ticket` | string | `opus` | Model for the work step's agent (`auto-work`). |
 | `model_review_ticket` | string | `opus` | Model for the review step's agent (`auto-review`). |
 | `model_pr_feedback` | string | `sonnet` | Model for the pr-feedback step's agent (`auto-feedback`). |

--- a/skills/auto-ticket/autonomous-contract.md
+++ b/skills/auto-ticket/autonomous-contract.md
@@ -54,6 +54,7 @@ Which values each sub-skill can emit:
 | `work-ticket` | `done` \| `needs-human` |
 | `review-ticket` | `clean` \| `fixable-findings` \| `needs-human` |
 | `pr-feedback` | `done` \| `needs-human` |
+| `validate` | `done` \| `needs-human` |
 | `push` | `done` \| `needs-human` |
 | `finish-ticket` | `done` \| `needs-human` |
 
@@ -80,7 +81,7 @@ The single routine the orchestrator (or a standalone top-level sub-skill) runs w
 `/ccmagic:auto-ticket` stopped this run because it needs a human decision.
 
 **Waiting on:** {the one-line reason from the sub-skill's handshake}
-**Stage:** {work-ticket | review-ticket | pr-feedback | finish-ticket}
+**Stage:** {work-ticket | review-ticket | pr-feedback | validate | finish-ticket}
 **PR:** {pr_url or "not created"}
 **State moved to:** {needs_human_state, or "unchanged — applied label `{needs_human_label}`"}
 

--- a/skills/push/SKILL.md
+++ b/skills/push/SKILL.md
@@ -3,7 +3,7 @@ name: push
 user-invocable: true
 description: Smart commit and push with logical grouping
 allowed-tools: Read(*), Bash(git:*), Glob(*), AskUserQuestion(*), Write(*)
-model: sonnet
+model: haiku
 ---
 
 # Push Command

--- a/skills/review-ticket/SKILL.md
+++ b/skills/review-ticket/SKILL.md
@@ -4,7 +4,7 @@ description: Ticket-grounded code review. Fetches the ticket from Linear, GitHub
 user-invocable: true
 allowed-tools: Read(*), Edit(*), Bash(git:*, gh:*), Glob(*), Grep(*), Agent(*), Task(*), TodoWrite(*), AskUserQuestion(*), Skill(*)
 argument-hint: "[TICKET-ID] [--threshold N]"
-model: sonnet
+model: inherit
 ---
 
 # /review-ticket — Ticket-Grounded Code Review

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -307,6 +307,30 @@ When validation fails:
 4. Create todos for complex fixes
 5. Prevent commit/PR until fixed
 
+## Autonomous mode
+
+`/ccmagic:validate` runs interactively by default. Autonomous mode is **opt-in and additive**: it runs the same checks without prompting and ends with a machine-readable handshake the orchestrator (`/ccmagic:auto-ticket`) parses. It never fixes code on its own — fixing is the caller's job.
+
+### When autonomous mode is active
+
+Autonomous mode is ON when the first present signal (in priority order) resolves truthy:
+
+1. `--autonomous` in the skill arguments.
+2. An `autonomous: true` line in the grounding/context block a parent skill (e.g. `/ccmagic:auto-ticket`) prepends when invoking this skill.
+3. `autonomous: true` in `ccmagic.local.md` frontmatter — the project file `.claude/ccmagic.local.md` first, then the user file `~/.claude/ccmagic.local.md`.
+
+Absent all three, run the interactive path exactly as documented above.
+
+`/ccmagic:validate` has no tracker access; it never moves a ticket. It runs the checks, reports the result, and emits the handshake — the parent skill/orchestrator owns any route-and-stop. Emit `done` when every check passes; emit `needs-human` when one or more checks fail, summarizing the failing checks on the `reason` line (the orchestrator decides whether to fix-and-retry or park). Auto-fix is **off** in autonomous mode — report failures, don't silently rewrite code.
+
+### Handshake (emit last, in autonomous mode)
+
+```
+status: done | needs-human
+reason: <one line — "validation passed" on done; the failing checks on needs-human>
+follow_ups: []
+```
+
 ## Execution
 
 Begin validation immediately without confirmation. Run checks in optimal order (fail fast on critical issues). Provide real-time progress updates. Display clear, actionable results with specific file:line references for issues.

--- a/skills/work-ticket/SKILL.md
+++ b/skills/work-ticket/SKILL.md
@@ -4,7 +4,7 @@ description: End-to-end ticket workflow. Detects your tracker (Linear, GitHub Is
 user-invocable: true
 allowed-tools: Read(*), Write(*), Edit(*), Bash(git:*, gh:*, mkdir:*), Glob(*), Grep(*), Task(*), TodoWrite(*), AskUserQuestion(*), Skill(*)
 argument-hint: Ticket ID (e.g. ENG-123, PROJ-456, or a GitHub issue number like 42)
-model: sonnet
+model: inherit
 ---
 
 # /work-ticket — End-to-End Ticket Workflow


### PR DESCRIPTION
## Summary

Upgrades `/ccmagic:auto-ticket` (shipped in 3.1.0) so each lifecycle step runs in its **own forked subagent** on a **best-fit per-step model**, instead of inline in one context. This keeps the orchestrator's context lean on long unattended runs (the Cyrus/headless path) and puts the right model on each step — strong where judgment matters, cheap where the step is mechanical.

Fully **additive and opt-in**: `fork_steps: false` restores the exact 3.1.0 inline flow, and the handshake contract is unchanged (it just returns across the subagent boundary now).

## What changed

- **`auto-ticket` is now `context: fork`** and routes every step through a `run_step` helper: forked to a per-step agent when `fork_steps` is true (default), inline via `Skill` otherwise.
- **Six thin wrapper agents** in `agents/auto-*.md` — each preloads its lifecycle skill and runs it on its own model. The five lifecycle skills' *logic* is reused unchanged.
- **Per-step models (Balanced default):** work/review → `opus`, pr-feedback/finish/validate → `sonnet`, push → `haiku`. Overridable per repo via `model_<step>` keys.
- **Model-clobber designed out at the source:** rather than rely only on a preload trick, the lifecycle skills' own models are tuned so they never fight the step-agent — `work-ticket`/`review-ticket` → `model: inherit`, `push` → `model: haiku`; `pr-feedback`/`finish-ticket`/`validate` stay `sonnet`. Every step then either *inherits* (nothing to clobber) or *matches* its step-agent, so per-step models are correct by construction.
- **New config:** `fork_steps` (bool, default `true`) + six `model_<step>` keys, documented in `ccmagic.local.md.example`, the contract §5, and the README.
- **Version → 3.2.0**; CHANGELOG entry added.

## Design + plan (on the branch)

- `docs/auto-ticket-per-step-subagents-design.md` — approved design spec (mechanism, config surface, risks).
- `docs/auto-ticket-per-step-subagents-plan.md` — the task-by-task implementation plan this branch executed.

## Heads-up: interactive behavior change

The model tuning affects **interactive** use of three skills too (documented in the CHANGELOG): `/ccmagic:push` now runs on `haiku`, and `/ccmagic:work-ticket` / `/ccmagic:review-ticket` now scale to your session model instead of a pinned `sonnet`. Both are sensible (push is trivial; work/review benefit from a stronger session), but calling it out since it's a shipped-default change.

## Validation

- Structural verification throughout (frontmatter parses, balanced fences, consistent config keys/models across SKILL/contract/README, valid manifests at 3.2.0).
- Final whole-branch review (opus): clean pass — no Critical/Important functional defects; the two Minors it raised (CHANGELOG "unchanged" wording, dangling agent code-fences) are fixed in this branch.
- **Remaining:** Task 7 — a live end-to-end smoke test in a tracker-connected repo (confirm a step actually forks + returns its handshake, and `fork_steps: false` falls back to inline). This is the same runtime bar the 3.1.0 auto-ticket merged on. Recommended before/right after merge: run `/ccmagic:auto-ticket` on a small ticket (e.g. a MagicMenu bugfix) and confirm in the task pane that steps spawn on their mapped models.

## Checklist
- [x] Additive & opt-in (`fork_steps: false` = 3.1.0 behavior)
- [x] Handshake contract unchanged (returns across the boundary)
- [x] Model-clobber designed out (skills inherit/match their step-agent)
- [x] Config keys documented; version bumped to 3.2.0
- [x] Final whole-branch review clean
- [ ] Live end-to-end smoke test (Task 7 — needs a tracker-connected repo)
