### PR TITLE
chore: pin tracker to linear for Cyrus prompt-relay runs

### DIFF
--- a/.claude/ccmagic.local.md
+++ b/.claude/ccmagic.local.md
@@ -1,0 +1,10 @@
+---
+# ccmagic project config for this repo (consumed by ccmagic skills on both
+# laptop and Cyrus runs). Pins the tracker so the auto-ticket prompt-relay
+# transport detects Linear deterministically inside the Cyrus container, where
+# there is no Linear MCP to probe and an `ENG-123`-shaped ID is otherwise
+# ambiguous between Linear and JIRA. See docs/ccmagic.local.md.example for the
+# full set of available keys.
+tracker: linear
+github_repo: devondragon/ccmagic
+---


### PR DESCRIPTION
## What

Adds `.claude/ccmagic.local.md` pinning `tracker: linear` (and `github_repo`) for the ccmagic repo itself.

## Why

Cyrus runs `/ccmagic:auto-ticket` inside a container with **no Linear MCP**. The v3.3.0 prompt-relay transport resolves the tracker via the same cascade as `work-ticket` Step 0, whose **first** step is settings. Without a pin, an `ENG-123`-shaped Linear ID is ambiguous with JIRA and detection falls back to a best-guess. Pinning `tracker: linear` makes in-container detection deterministic. The file is per-repo and works unchanged on a laptop.

This is the last of the deployment prerequisites from `docs/cyrus-deployment.md` (§3). The Cyrus container itself is already set up: ccmagic 3.3.0 installed as the user-skills plugin (scoped to this repo), the ccmagic repo wired to an auto-ticket prompt template, tools widened, and Cyrus restarted.

## How to test

Assign a throwaway Linear issue in the ccmagic project to the Cyrus agent and confirm the relayed final comment matches the run summary verbatim (design doc R1).