### PR TITLE
fix(doctor): repair plugin-root checks and surface resolved config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ccmagic",
       "source": "./",
       "description": "24 dev workflow skills: tracker-aware ticket lifecycle (Linear, GitHub, JIRA) with an autonomous end-to-end driver, adaptive code review, debugging, design/QA, and git workflow utilities",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "author": {
         "name": "Devon Hillard"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmagic",
   "description": "Dev workflow skills for Claude Code: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": { "name": "Devon Hillard", "url": "https://github.com/devondragon" },
   "repository": "https://github.com/devondragon/ccmagic",
   "license": "Apache-2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ccmagic are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] — 2026-07
+
+### Fixed
+
+- **`doctor` ran two dead checks and under-reported config** (`skills/doctor/SKILL.md`) — the commit-hook (§4) and skill-inventory (§7) checks located the plugin via `claude plugins show ccmagic --path`, which is not a real CLI subcommand; wrapped in `$(… 2>/dev/null)` the failure was swallowed and the substitution returned empty, so the hook check always ran `test -f "/hooks/…"` against the filesystem root (always "missing") and the inventory check `ls`-ed a nonexistent `/skills` (always skipped). Both now resolve via `$CLAUDE_PLUGIN_ROOT` (the variable already used by `hooks/hooks.json`), degrading to an `INFO` line when it is unset rather than emitting a false failure. Additionally, the project-config section (§2) now parses `.claude/ccmagic.local.md` frontmatter and echoes the resolved `tracker`, `ticket_url_base`, `ticket_id_regex`, `default_qa_workflow`, `github_repo`, `autonomous`, and `needs_human_label` values (falling back to documented defaults for absent/commented keys) instead of only describing what it would report.
+
 ## [3.6.0] — 2026-07
 
 Field hardening from the FullAuto smoke test on the live [Cyrus](https://github.com/cyrusagents/cyrus) instance: a run implemented a ticket, opened and reviewed the PR, then — unable to read the PR's checks — **ended by asking a human to confirm CI was green** instead of merging or parking. The root cause is not the pipeline but the token: Cyrus authenticates with a **fine-grained PAT**, and fine-grained PATs cannot read check runs authored by a GitHub App (GitHub Actions, and bot reviewers like Copilot/Claude, are Apps), so `gh pr checks` / `statusCheckRollup` return `Resource not accessible by personal access token` (HTTP 403) even with `Checks: read` granted. The Actions API (`gh run …`) and the Status API stay readable with `Actions: read` + `Commit statuses: read`.

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -31,16 +31,25 @@ test -f context/knowledge/CONVENTIONS.md && echo "OK   context/knowledge/CONVENT
 ### 2. ccmagic project configuration
 
 ```bash
-test -f .claude/ccmagic.local.md && echo "OK   .claude/ccmagic.local.md" || echo "INFO .claude/ccmagic.local.md missing — tracker will auto-detect"
+CFG=.claude/ccmagic.local.md
+if [ -f "$CFG" ]; then
+  echo "OK   $CFG present — resolved settings:"
+  # Read a key from the YAML frontmatter (ignoring commented # lines);
+  # print the value, or the $2 default when the key is absent/blank.
+  cfg() { local v; v=$(grep -E "^\s*$1\s*:" "$CFG" 2>/dev/null | grep -v '^\s*#' | head -1 | sed -E "s/^\s*$1\s*:\s*//" | sed -E 's/\s*#.*$//' | tr -d '"' | xargs); echo "${v:-$2}"; }
+  echo "     tracker            = $(cfg tracker 'auto (default)')"
+  echo "     ticket_url_base    = $(cfg ticket_url_base 'not set')"
+  echo "     ticket_id_regex    = $(cfg ticket_id_regex '[A-Z][A-Z0-9]+-[0-9]+ (default)')"
+  echo "     default_qa_workflow= $(cfg default_qa_workflow 'false (default)')"
+  echo "     github_repo        = $(cfg github_repo 'auto-detect via gh')"
+  echo "     autonomous         = $(cfg autonomous 'false (default)')"
+  echo "     needs_human_label  = $(cfg needs_human_label 'needs-human (default)')"
+else
+  echo "INFO $CFG missing — tracker auto-detects on each ticket skill invocation (not broken, just not pinned)"
+fi
 ```
 
-If `.claude/ccmagic.local.md` exists, read its YAML frontmatter and report:
-- Active `tracker:` value (`linear`, `github`, `jira`, or `auto`)
-- `ticket_url_base` (or "not set")
-- `ticket_id_regex` (or the default `[A-Z][A-Z0-9]+-[0-9]+`)
-- `default_qa_workflow` (`true` / `false`)
-
-If the file is missing entirely, note that tracker auto-detection will run on each ticket skill invocation — not broken, just not pinned.
+Echo the values the parse produced verbatim into the report's **Tracker integration** section — a blank `tracker` in the config resolves to `auto`, and blank optional keys fall back to the defaults shown above. Feed the resolved `tracker` value into section 3 so the report probes the right integration, and the resolved `ticket_id_regex` into section 6.
 
 ### 3. Tracker integration availability
 
@@ -72,12 +81,16 @@ For Linear and JIRA, surface this checklist in the report instead of trying to p
 ### 4. Commit hook
 
 ```bash
-test -f "$(claude plugins show ccmagic --path 2>/dev/null)/hooks/post-tool-use-commit.sh" \
-  && echo "OK   commit-format hook installed" \
-  || echo "INFO commit-format hook not found via plugin path — check that ccmagic is installed as a plugin"
+if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -f "$CLAUDE_PLUGIN_ROOT/hooks/post-tool-use-commit.sh" ]; then
+  echo "OK   commit-format hook installed ($CLAUDE_PLUGIN_ROOT/hooks/post-tool-use-commit.sh)"
+elif [ -n "$CLAUDE_PLUGIN_ROOT" ]; then
+  echo "WARN CLAUDE_PLUGIN_ROOT set but hooks/post-tool-use-commit.sh missing — reinstall the ccmagic plugin"
+else
+  echo "INFO CLAUDE_PLUGIN_ROOT not set — can't locate the plugin dir from here; the hook ships with the plugin and runs automatically on git commits"
+fi
 ```
 
-If the `claude plugins` CLI isn't available, fall back to a softer check: just note in the report that the hook ships with the plugin and runs automatically on `git commit` calls made by Claude Code.
+`$CLAUDE_PLUGIN_ROOT` is the plugin root exported to plugin skills (the same variable `hooks/hooks.json` uses). If it isn't set, fall back to the note above rather than reporting a false failure.
 
 ### 5. Git configuration
 
@@ -110,10 +123,15 @@ Then test the branch name against the ticket regex (or integer for GitHub) and r
 ### 7. Skill availability
 
 ```bash
-ls "$(claude plugins show ccmagic --path 2>/dev/null)/skills" 2>/dev/null | head -50
+if [ -n "$CLAUDE_PLUGIN_ROOT" ] && [ -d "$CLAUDE_PLUGIN_ROOT/skills" ]; then
+  echo "OK   $(ls "$CLAUDE_PLUGIN_ROOT/skills" | wc -l | tr -d ' ') skills present:"
+  ls "$CLAUDE_PLUGIN_ROOT/skills" | sort | column -c 80 2>/dev/null || ls "$CLAUDE_PLUGIN_ROOT/skills" | sort
+else
+  echo "INFO CLAUDE_PLUGIN_ROOT not set — skipping skill inventory"
+fi
 ```
 
-Compare against the expected skill list. If the `claude plugins` CLI isn't available, skip this check.
+Compare against the expected skill list. If `$CLAUDE_PLUGIN_ROOT` isn't set, skip this check.
 
 ## Report Output
 


### PR DESCRIPTION
## Summary

The `doctor` skill's setup health check had two checks that never actually ran, plus one section that only *described* its output instead of producing it. This fixes both.

## Changes

- **Sections 4 & 7 were dead code.** Both located the plugin via `claude plugins show ccmagic --path` — not a real CLI subcommand (`claude plugins` has no `show`/`--path`). Wrapped in `$(… 2>/dev/null)`, the failure was swallowed and the substitution returned an empty string, so:
  - the commit-hook check ran `test -f "/hooks/…"` against the filesystem root and *always* reported the hook missing;
  - the skill-inventory check `ls`-ed a nonexistent `/skills` and silently produced nothing.

  Both now use `$CLAUDE_PLUGIN_ROOT` (the variable already exported to plugin skills and used by `hooks/hooks.json`), and degrade to an `INFO` line if it's unset rather than emitting a false failure.

- **Section 2 now reports resolved config.** It previously only described what it *would* report. It now parses `.claude/ccmagic.local.md` frontmatter and echoes `tracker`, `ticket_url_base`, `ticket_id_regex`, `default_qa_workflow`, `github_repo`, `autonomous`, and `needs_human_label`, falling back to documented defaults for absent/commented keys. The resolved `tracker` and `ticket_id_regex` feed sections 3 and 6.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Manual testing — verified both `$CLAUDE_PLUGIN_ROOT` blocks resolve against the repo (hook found, 25 skills listed) and the section-2 parser handles present, commented-out, and absent keys correctly.

## Notes for reviewers

Not addressed (out of scope): section 3 still can't probe Linear/JIRA MCP connectivity from bash — that's an inherent limitation of the forked bash context, and the skill already explains it. Only `gh` gets a live probe.