### PR TITLE
fix(validate): remove broken commands, stop masking failures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "ccmagic",
       "source": "./",
       "description": "24 dev workflow skills: tracker-aware ticket lifecycle (Linear, GitHub, JIRA) with an autonomous end-to-end driver, adaptive code review, debugging, design/QA, and git workflow utilities",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "author": {
         "name": "Devon Hillard"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmagic",
   "description": "Dev workflow skills for Claude Code: tracker-aware ticket lifecycle (Linear, GitHub, JIRA), adaptive code review, debugging, design/QA, and git workflow utilities",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "author": { "name": "Devon Hillard", "url": "https://github.com/devondragon" },
   "repository": "https://github.com/devondragon/ccmagic",
   "license": "Apache-2.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to ccmagic are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2] — 2026-07
+
+### Fixed
+
+- **`validate` catalogued broken commands and could mask real failures** (`skills/validate/SKILL.md`) — two illustrative commands didn't work as written: `python -m ast **/*.py` (§2) errors on more than one file (the `ast` CLI accepts a single file, and `py_compile` on the line above already covers multi-file syntax checking), and `npx eslint --no-eslintrc --parser espree --no-config` (§2) uses flags that don't coexist (`--no-eslintrc` was removed in ESLint 9) with no target path. Removed the former and replaced the latter with `node --check`. Also reframed the `||` command chains: a check tool exiting non-zero usually means a real failure (lint errors, failing tests), so chaining past it with `||` masked that failure by falling through to the next tool. Added a note under *Implementation Steps* clarifying that `||` denotes *"whichever tool this project uses"* — pick one per detected stack, don't shell-fallback — split the cross-stack test chain (§6) into per-language lines, and hardened the autonomous-mode handshake (§10) to state that a non-zero exit from any selected check is a failure and must never be converted to a pass, since it gates the `/ccmagic:auto-ticket` merge decision.
+
 ## [3.6.1] — 2026-07
 
 ### Fixed

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -27,6 +27,8 @@ Comprehensive pre-commit validation to ensure code quality, tests pass, and chan
 
 ## Implementation Steps
 
+> **How to read the command blocks below.** These are a catalog, not a script to run verbatim. After Step 1 detects the project's stack and tooling, **select the single command that matches** — do not run them all. Where a block chains alternatives with `||` (e.g. `pylint || flake8 || ruff check`, `npm audit || yarn audit`), the `||` denotes *"whichever of these tools this project actually uses"* — **pick the one that's configured, not a shell fallback**. A check tool exiting non-zero almost always means a real failure (lint errors, failing tests), so chaining past it with `||` would mask that failure by falling through to the next tool. Run one command per check and read its exit code directly.
+
 ### 1. Detect Project Type and Tools
 
 ```bash
@@ -47,17 +49,14 @@ ls -la | grep -E ".prettierrc|black.toml|.rustfmt"
 # TypeScript compilation
 npx tsc --noEmit
 
-# JavaScript syntax check
-npx eslint --no-eslintrc --parser espree --no-config
+# Plain-JS syntax check (per file; no config needed)
+node --check path/to/file.js
 ```
 
 #### Python
 ```bash
-# Syntax check
+# Syntax check (accepts multiple files)
 python -m py_compile **/*.py
-
-# AST validation
-python -m ast **/*.py
 ```
 
 #### Go
@@ -121,11 +120,13 @@ cargo fmt -- --check
 ### 6. Test Execution
 
 ```bash
-# Run tests with coverage
-npm test -- --coverage || pytest --cov || go test -cover ./... || cargo test
+# Run tests with coverage — pick the line for the detected stack
+npm test -- --coverage   # JavaScript/TypeScript
+pytest --cov             # Python
+go test -cover ./...     # Go
+cargo test               # Rust
 
-# Check coverage thresholds
-# Fail if coverage < 80%
+# Then check coverage against the threshold (default 80%; see .validation.json)
 ```
 
 ### 7. Security Scanning
@@ -322,6 +323,8 @@ Autonomous mode is ON when the first present signal (in priority order) resolves
 Absent all three, run the interactive path exactly as documented above.
 
 `/ccmagic:validate` has no tracker access; it never moves a ticket. It runs the checks, reports the result, and emits the handshake — the parent skill/orchestrator owns any route-and-stop. Emit `done` when every check passes; emit `needs-human` when one or more checks fail, summarizing the failing checks on the `reason` line (the orchestrator decides whether to fix-and-retry or park). Auto-fix is **off** in autonomous mode — report failures, don't silently rewrite code.
+
+**A non-zero exit from any selected check is a failure.** Because this handshake gates a merge decision in `/ccmagic:auto-ticket`, never let a `||` chain convert a real failure into a pass by falling through to another tool (see the note under *Implementation Steps*): run the one command that matches the detected stack and treat its exit code as authoritative. Emit `done` only when *every* selected check exited zero.
 
 ### Handshake (emit last, in autonomous mode)
 


### PR DESCRIPTION
## Summary

Audit of the `validate` skill (follow-up to the `doctor` audit in #26) surfaced two broken commands and a failure-masking pattern. Unlike `doctor`, `validate` is a *catalog the model selects from* after detecting the stack — so these are guidance defects, but one has real autonomous-mode consequences.

## Changes

- **Broken commands removed/fixed (§2):**
  - `python -m ast **/*.py` — the `ast` CLI accepts a single file; a multi-file glob errors out. Removed (the `py_compile` line above already does multi-file syntax checking).
  - `npx eslint --no-eslintrc --parser espree --no-config` — flags that don't coexist (`--no-eslintrc` was removed in ESLint 9) and no target path. Replaced with `node --check`.
- **`||` chains no longer mask failures:** a check tool exiting non-zero usually means a *real* failure (lint errors, failing tests), so `toolA || toolB` fell through and hid it. Added a note under *Implementation Steps* clarifying `||` means "whichever tool this project uses — pick one per detected stack, not a shell fallback," and split the cross-stack test chain (§6) into per-language lines.
- **Autonomous handshake hardened (§10):** explicitly states a non-zero exit from any selected check is a failure and must never be converted to a pass — this matters because the handshake gates the `/ccmagic:auto-ticket` merge decision.
- **Version bump** 3.6.1 → 3.6.2 + changelog.

## Type of Change
- [x] Bug fix (non-breaking)

## Testing
- [x] Verified `python -m ast` errors on multiple files and `py_compile` accepts them; confirmed the repo has no toolchain manifests (validate is guidance here, not run locally).